### PR TITLE
List modules freeipa-healthcheck depends on in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,12 @@ setup(
         'ipahealthcheck.ipa',
         'ipahealthcheck.meta'
     ],
+    install_requires=[
+          'ipaplatform',
+          'ipalib',
+          'ipaserver',
+          'ipapython',
+      ],
     entry_points={
         # creates bin/ipahealthcheck
         'console_scripts': [


### PR DESCRIPTION
f28 and up can use the automatic Python dependency generator if
required modules are listed in setup.py.

Source:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_dependencies
Example:
https://python-packaging.readthedocs.io/en/latest/dependencies.html