### PR TITLE
Error out of a source or check is requested and is not found

### DIFF
--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -188,6 +188,14 @@ def main():
     else:
         results = None
 
+    if options.source and len(results.results) == 0:
+        if options.check:
+            print("Check '%s' not found in Source '%s'" %
+                  (options.check, options.source))
+        else:
+            print("Source '%s' not found" % options.source)
+        sys.exit(1)
+
     try:
         output.render(results)
     except Exception as e:


### PR DESCRIPTION
Otherwise it returns an empty list which makes it unclear
whether something was executed incorrectly or not at all.