### PR TITLE
Use ipatopologysuffix-verify to validate replication topology

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
             'ipacerts = ipahealthcheck.ipa.certs',
             'ipafiles = ipahealthcheck.ipa.files',
             'ipahost = ipahealthcheck.ipa.host',
+            'ipatopology = ipahealthcheck.ipa.topology',
         ],
         # plugin modules for ipahealthcheck.dogtag registry
         'ipahealthcheck.dogtag': [

--- a/src/ipahealthcheck/ipa/topology.py
+++ b/src/ipahealthcheck/ipa/topology.py
@@ -1,0 +1,76 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+import logging
+
+from ipahealthcheck.ipa.plugin import IPAPlugin, registry
+from ipahealthcheck.core.plugin import Result
+from ipahealthcheck.core.plugin import duration
+from ipahealthcheck.core import constants
+
+from ipalib import api
+
+logger = logging.getLogger()
+
+
+@registry
+class IPATopologyDomainCheck(IPAPlugin):
+    """
+    Execute the equivalant of ipa topologysuffix-verify domain
+
+    Return any errors discovered. This can include:
+      * too many agreements
+      * connection errors
+    """
+    def report_errors(self, suffix, result):
+        if result['result']['in_order']:
+            yield Result(self, constants.SUCCESS, suffix=suffix)
+        else:
+            max_agmts = result['result']['max_agmts']
+            connect_errors = result['result']['connect_errors']
+            max_agmts_errors = result['result']['max_agmts_errors']
+            cmsg = 'Server %(srv)s can\'t contact servers: %(replicas)s'
+            mmsg = 'Server "%(srv)s" has %(n)d agreements, recommended ' \
+                   'max %(m)d'
+
+            if connect_errors:
+                for error in connect_errors:
+                    msg = cmsg % {'srv': error[0],
+                                  'replicas': ', '.join(error[1])}
+                    yield Result(self, constants.ERROR,
+                                 key=error[0],
+                                 replicas=error[2],
+                                 suffix=suffix,
+                                 type='connect',
+                                 msg=msg)
+            if max_agmts_errors:
+                for error in max_agmts_errors:
+                    msg = mmsg % {'srv': error[0],
+                                  'n': len(error[1]),
+                                  'm': max_agmts}
+                    yield Result(self, constants.ERROR,
+                                 key=error[0],
+                                 replicas=error[1],
+                                 suffix=suffix,
+                                 type='max',
+                                 msg=msg)
+
+    def run_check(self, suffix):
+        try:
+            result = api.Command.topologysuffix_verify(suffix)
+        except Exception as e:
+            yield Result(self, constants.ERROR,
+                         msg='topologysuffix-verify domain failed, %s' %
+                         e)
+        else:
+            for r in self.report_errors(suffix, result):
+                yield r
+
+    @duration
+    def check(self):
+
+        for y in self.run_check(u'domain'):
+            yield y
+        for y in self.run_check(u'ca'):
+            yield y

--- a/tests/test_ipa_topology.py
+++ b/tests/test_ipa_topology.py
@@ -1,0 +1,220 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+from util import capture_results
+from util import m_api
+from base import BaseTest
+from unittest.mock import Mock
+
+from ipahealthcheck.core import config, constants
+from ipahealthcheck.ipa.plugin import registry
+from ipahealthcheck.ipa.topology import IPATopologyDomainCheck
+
+
+class TestTopology(BaseTest):
+    patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        Mock(return_value=None),
+    }
+
+    def test_topology_ok(self):
+        m_api.Command.topologysuffix_verify.side_effect = [
+            {
+                u'result': {
+                    u"in_order": True,
+                }
+            },
+            {
+                u'result': {
+                    u"in_order": True,
+                }
+            },
+        ]
+
+        framework = object()
+        registry.initialize(framework)
+        f = IPATopologyDomainCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+
+        for result in self.results.results:
+            assert result.severity == constants.SUCCESS
+            assert result.source == 'ipahealthcheck.ipa.topology'
+            assert result.check == 'IPATopologyDomainCheck'
+
+    def test_topology_domain_bad(self):
+        m_api.Command.topologysuffix_verify.side_effect = [
+            {
+                u'result': {
+                    u"connect_errors": [
+                        [
+                            u"ipa.example.test",
+                            [u"ipa.example.test"],
+                            [u"replica2.example.test"]
+                        ],
+                        [
+                            u"replica2.example.test",
+                            [u"replica2.example.test"],
+                            [u"ipa.example.test"]
+                        ]
+                    ],
+                    u"in_order": False,
+                    u"max_agmts": 4,
+                    u"max_agmts_errors": []
+                }
+            },
+            {
+                u'result': {
+                    u"in_order": True,
+                }
+            },
+        ]
+
+        framework = object()
+        registry.initialize(framework)
+        f = IPATopologyDomainCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 3
+
+        for result in self.results.results:
+            assert result.source == 'ipahealthcheck.ipa.topology'
+            assert result.check == 'IPATopologyDomainCheck'
+
+        # The first two results are failures in the domain suffix, the
+        # third is a success in the ca suffix.
+        result = self.results.results[0]
+        assert result.severity == constants.ERROR
+        assert result.kw.get('key') == 'ipa.example.test'
+        assert result.kw.get('replicas') == ['replica2.example.test']
+        assert result.kw.get('suffix') == 'domain'
+        assert result.kw.get('type') == 'connect'
+        assert 'can\'t contact servers' in result.kw.get('msg')
+
+        result = self.results.results[1]
+        assert result.severity == constants.ERROR
+        assert result.kw.get('key') == 'replica2.example.test'
+        assert result.kw.get('replicas') == ['ipa.example.test']
+        assert result.kw.get('suffix') == 'domain'
+        assert result.kw.get('type') == 'connect'
+        assert 'can\'t contact servers' in result.kw.get('msg')
+
+        result = self.results.results[2]
+        assert result.severity == constants.SUCCESS
+        assert result.kw.get('suffix') == 'ca'
+
+    def test_topology_ca_bad(self):
+        m_api.Command.topologysuffix_verify.side_effect = [
+            {
+                u'result': {
+                    u"in_order": True,
+                }
+            },
+            {
+                u'result': {
+                    u"connect_errors": [
+                        [
+                            u"ipa.example.test",
+                            [u"ipa.example.test"],
+                            [u"replica2.example.test"]
+                        ],
+                        [
+                            u"replica2.example.test",
+                            [u"replica2.example.test"],
+                            [u"ipa.example.test"]
+                        ]
+                    ],
+                    u"in_order": False,
+                    u"max_agmts": 4,
+                    u"max_agmts_errors": []
+                }
+            },
+        ]
+
+        framework = object()
+        registry.initialize(framework)
+        f = IPATopologyDomainCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 3
+
+        for result in self.results.results:
+            assert result.source == 'ipahealthcheck.ipa.topology'
+            assert result.check == 'IPATopologyDomainCheck'
+
+        # The first result is ok (domain) and the last two are failures
+        # (ca)
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.kw.get('suffix') == 'domain'
+
+        result = self.results.results[1]
+        assert result.severity == constants.ERROR
+        assert result.kw.get('key') == 'ipa.example.test'
+        assert result.kw.get('replicas') == ['replica2.example.test']
+        assert result.kw.get('suffix') == 'ca'
+        assert result.kw.get('type') == 'connect'
+        assert 'can\'t contact servers' in result.kw.get('msg')
+
+        result = self.results.results[2]
+        assert result.severity == constants.ERROR
+        assert result.kw.get('key') == 'replica2.example.test'
+        assert result.kw.get('replicas') == ['ipa.example.test']
+        assert result.kw.get('suffix') == 'ca'
+        assert result.kw.get('type') == 'connect'
+        assert 'can\'t contact servers' in result.kw.get('msg')
+
+    def test_topology_domain_max_agmts(self):
+        m_api.Command.topologysuffix_verify.side_effect = [
+            {
+                u'result': {
+                    u"connect_errors": [],
+                    u"in_order": False,
+                    u"max_agmts": 1,
+                    u"max_agmts_errors": [
+                        [
+                            u"ipa.example.test",
+                            [u"replica2.example.test"],
+                        ],
+                    ],
+                }
+            },
+            {
+                u'result': {
+                    u"in_order": True,
+                }
+            },
+        ]
+
+        framework = object()
+        registry.initialize(framework)
+        f = IPATopologyDomainCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+
+        for result in self.results.results:
+            assert result.source == 'ipahealthcheck.ipa.topology'
+            assert result.check == 'IPATopologyDomainCheck'
+
+        result = self.results.results[0]
+        assert result.severity == constants.ERROR
+        assert result.kw.get('key') == 'ipa.example.test'
+        assert result.kw.get('replicas') == ['replica2.example.test']
+        assert result.kw.get('suffix') == 'domain'
+        assert result.kw.get('type') == 'max'
+        assert 'recommended max' in result.kw.get('msg')
+
+        result = self.results.results[1]
+        assert result.severity == constants.SUCCESS
+        assert result.kw.get('suffix') == 'ca'


### PR DESCRIPTION
Both the ca and domain suffixes are evaluated and reported.

The results can be differentiated by the suffix of domain and ca
and the type of results, connection errors or too many agreements,
can be distinguished by 'type'.