### PR TITLE
The RA agent certificate is tracked on all masters, not just CAs

### DIFF
--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -55,18 +55,15 @@ def get_expected_requests(ca, ds, serverid):
     """
     template = paths.CERTMONGER_COMMAND_TEMPLATE
 
-    if ca.is_configured():
-        requests = [
-            {
-                'cert-file': paths.RA_AGENT_PEM,
-                'key-file': paths.RA_AGENT_KEY,
-                'ca-name': 'dogtag-ipa-ca-renew-agent',
-                'cert-presave-command': template % 'renew_ra_cert_pre',
-                'cert-postsave-command': template % 'renew_ra_cert',
-            },
-        ]
-    else:
-        requests = []
+    requests = [
+        {
+            'cert-file': paths.RA_AGENT_PEM,
+            'key-file': paths.RA_AGENT_KEY,
+            'ca-name': 'dogtag-ipa-ca-renew-agent',
+            'cert-presave-command': template % 'renew_ra_cert_pre',
+            'cert-postsave-command': template % 'renew_ra_cert',
+        },
+    ]
 
     ca_requests = [
         {


### PR DESCRIPTION
The RA agent cert was only being checked in IPACertTracking when
a CA was configured causing it to display a false-positive of
an unknown certificate on masters without a CA.