### PR TITLE
Fix execution in CAless environment

### DIFF
--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -55,15 +55,18 @@ def get_expected_requests(ca, ds, serverid):
     """
     template = paths.CERTMONGER_COMMAND_TEMPLATE
 
-    requests = [
-        {
-            'cert-file': paths.RA_AGENT_PEM,
-            'key-file': paths.RA_AGENT_KEY,
-            'ca-name': 'dogtag-ipa-ca-renew-agent',
-            'cert-presave-command': template % 'renew_ra_cert_pre',
-            'cert-postsave-command': template % 'renew_ra_cert',
-        },
-    ]
+    if api.Command.ca_is_enabled()['result']:
+        requests = [
+            {
+                'cert-file': paths.RA_AGENT_PEM,
+                'key-file': paths.RA_AGENT_KEY,
+                'ca-name': 'dogtag-ipa-ca-renew-agent',
+                'cert-presave-command': template % 'renew_ra_cert_pre',
+                'cert-postsave-command': template % 'renew_ra_cert',
+            },
+        ]
+    else:
+        requests = []
 
     ca_requests = [
         {

--- a/src/ipahealthcheck/ipa/topology.py
+++ b/src/ipahealthcheck/ipa/topology.py
@@ -72,5 +72,6 @@ class IPATopologyDomainCheck(IPAPlugin):
 
         for y in self.run_check(u'domain'):
             yield y
-        for y in self.run_check(u'ca'):
-            yield y
+        if api.Command.ca_is_enabled()['result']:
+            for y in self.run_check(u'ca'):
+                yield y

--- a/tests/test_ipa_topology.py
+++ b/tests/test_ipa_topology.py
@@ -31,6 +31,7 @@ class TestTopology(BaseTest):
                 }
             },
         ]
+        m_api.Command.ca_is_enabled.return_value = {'result': True}
 
         framework = object()
         registry.initialize(framework)
@@ -73,6 +74,7 @@ class TestTopology(BaseTest):
                 }
             },
         ]
+        m_api.Command.ca_is_enabled.return_value = {'result': True}
 
         framework = object()
         registry.initialize(framework)
@@ -136,6 +138,7 @@ class TestTopology(BaseTest):
                 }
             },
         ]
+        m_api.Command.ca_is_enabled.return_value = {'result': True}
 
         framework = object()
         registry.initialize(framework)
@@ -193,6 +196,7 @@ class TestTopology(BaseTest):
                 }
             },
         ]
+        m_api.Command.ca_is_enabled.return_value = {'result': True}
 
         framework = object()
         registry.initialize(framework)


### PR DESCRIPTION
The RA agent cert will be tracked on a master even if it
doesn't have an installed CA but it won't be there if there
is no CA at all in the topology.

Similarly, only check the ca toplogy suffix when a CA is
installed anywhere.