### PR TITLE
Ensure that no_schema is set when creating fake LDAP connections

### DIFF
--- a/tests/test_ds_replication.py
+++ b/tests/test_ds_replication.py
@@ -67,12 +67,11 @@ class TestReplicationConflicts(BaseTest):
                         reason="no way of currently testing this")
     @patch('ipapython.ipaldap.LDAPClient.from_realm')
     def test_conflicts(self, mock_conn):
-
         attrs = dict(
             nsds5ReplConflict=['deletedEntryHasChildren'],
             objectclass=['top']
         )
-        fake_conn = LDAPClient('ldap://localhost')
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
         ldapentry = LDAPEntry(fake_conn, DN('cn=conflict', m_api.env.domain))
         for attr, values in attrs.items():
             ldapentry[attr] = values

--- a/tests/test_ipa_agent.py
+++ b/tests/test_ipa_agent.py
@@ -72,7 +72,7 @@ class TestNSSAgent(BaseTest):
             description=['2;1;CN=ISSUER;CN=RA AGENT'],
             usercertificate=[self.cert],
         )
-        fake_conn = LDAPClient('ldap://localhost')
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
         ldapentry = LDAPEntry(fake_conn, DN('uid=ipara,ou=people,o=ipaca'))
         for attr, values in attrs.items():
             ldapentry[attr] = values
@@ -93,7 +93,7 @@ class TestNSSAgent(BaseTest):
         attrs = dict(
             usercertificate=[self.cert],
         )
-        fake_conn = LDAPClient('ldap://localhost')
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
         ldapentry = LDAPEntry(fake_conn, DN('uid=ipara,ou=people,o=ipaca'))
         for attr, values in attrs.items():
             ldapentry[attr] = values
@@ -146,7 +146,7 @@ class TestNSSAgent(BaseTest):
             description=['2;1;CN=ISSUER;CN=RA AGENT'],
             usercertificate=[self.cert],
         )
-        fake_conn = LDAPClient('ldap://localhost')
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
         ldapentry = LDAPEntry(fake_conn, DN('uid=ipara,ou=people,o=ipaca'))
         for attr, values in attrs.items():
             ldapentry[attr] = values
@@ -175,7 +175,7 @@ class TestNSSAgent(BaseTest):
             description=['2;1;CN=ISSUER;CN=RA AGENT'],
             usercertificate=[cert2],
         )
-        fake_conn = LDAPClient('ldap://localhost')
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
         ldapentry = LDAPEntry(fake_conn, DN('uid=ipara,ou=people,o=ipaca'))
         for attr, values in attrs.items():
             ldapentry[attr] = values
@@ -200,7 +200,7 @@ class TestNSSAgent(BaseTest):
             description=['2;1;CN=ISSUER;CN=RA AGENT'],
             usercertificate=[cert2, self.cert],
         )
-        fake_conn = LDAPClient('ldap://localhost')
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
         ldapentry = LDAPEntry(fake_conn, DN('uid=ipara,ou=people,o=ipaca'))
         for attr, values in attrs.items():
             ldapentry[attr] = values


### PR DESCRIPTION
This is necessary for testing when no IPA master is installed.

The "fake" connection is never actually used, the operations are
mocked away, but a real LDAPClient object is needed because of
assertions within the ipaldap code.