### PR TITLE
Fix conversion of JSON to Result so that kw works in human output

### DIFF
--- a/src/ipahealthcheck/core/plugin.py
+++ b/src/ipahealthcheck/core/plugin.py
@@ -202,7 +202,8 @@ def json_to_results(data):
         severity = line.pop('severity')
         source = line.pop('source')
         check = line.pop('check')
-        result = Result(None, severity, source, check, **line)
+        kw = line.pop('kw')
+        result = Result(None, severity, source, check, **kw)
         results.add(result)
 
     return results


### PR DESCRIPTION
When loading a JSON file it is converted into Result objects.
This was being done incorrectly for the kw data type. The entire
line was being passed in as kw instead of the kw directly.