### PR TITLE
Add a system plugin and a file system free space check.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
         'ipahealthcheck.dogtag',
         'ipahealthcheck.ds',
         'ipahealthcheck.ipa',
-        'ipahealthcheck.meta'
+        'ipahealthcheck.meta',
+        'ipahealthcheck.system'
     ],
     entry_points={
         # creates bin/ipahealthcheck
@@ -25,6 +26,7 @@ setup(
             'ipahealthcheck.ipa = ipahealthcheck.ipa.plugin:registry',
             'ipahealthcheck.meta = ipahealthcheck.meta.plugin:registry',
             'ipahealthcheck.ds = ipahealthcheck.ds.plugin:registry',
+            'ipahealthcheck.system = ipahealthcheck.system.plugin:registry'
         ],
         # plugin modules for ipahealthcheck.meta registry
         'ipahealthcheck.meta': [
@@ -45,6 +47,10 @@ setup(
         # plugin modules for ipahealthcheck.ds registry
         'ipahealthcheck.ds': [
             'dsreplication = ipahealthcheck.ds.replication',
+        ],
+        # plugin modules for ipahealthcheck.system registry
+        'ipahealthcheck.system': [
+            'filesystemspace = ipahealthcheck.system.filesystemspace',
         ],
     },
     classifiers=[

--- a/src/ipahealthcheck/system/filesystemspace.py
+++ b/src/ipahealthcheck/system/filesystemspace.py
@@ -1,0 +1,81 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+import shutil
+
+from ipahealthcheck.system.plugin import SystemPlugin, registry
+from ipahealthcheck.core.plugin import Result
+from ipahealthcheck.core import constants
+
+
+@registry
+class FileSystemSpaceCheck(SystemPlugin):
+    """
+    """
+
+    # watch important directories for FreeIPA
+    _pathchecks = {
+        '/var/lib/dirsrv/': 1024,
+        '/var/log/': 1024,
+        '/var/log/audit/': 512,
+        '/var/tmp/': 512,
+        '/tmp': 512
+    }
+
+    # File systems reaching 90% capacity risk fragmentation.
+    # Defragmentation is never desirable and not available
+    # on ext4 anyway. So error out at 20% free space.
+    min_free_percent = 20
+
+    def get_fs_free_space(self, pathname):
+        stat = shutil.disk_usage(pathname)
+        return int(stat.free / 2**20)
+
+    def get_fs_free_space_percentage(self, pathname):
+        stat = shutil.disk_usage(pathname)
+        return int(stat.free * 100 / stat.total)
+
+    def check(self):
+        for store in self._pathchecks:
+            percent_free = self.get_fs_free_space_percentage(store)
+            if percent_free < self.min_free_percent:
+                yield Result(
+                    self, constants.ERROR,
+                    msg='%s: %s %s%% < %s%%' % (
+                        store, 'free space percentage under threshold:',
+                        percent_free, self.min_free_percent
+                    ),
+                    store=store, percent_free=percent_free,
+                    threshold=self.min_free_percent
+                )
+            else:
+                yield Result(
+                    self, constants.SUCCESS,
+                    msg='%s: %s %s%% >= %s%%' % (
+                        store, 'free space percentage within limits:',
+                        percent_free, self.min_free_percent
+                    ),
+                    store=store, percent_free=percent_free,
+                    threshold=self.min_free_percent
+                )
+            free_space = self.get_fs_free_space(store)
+            threshold = self._pathchecks[store]
+            if free_space < threshold:
+                yield Result(
+                     self, constants.ERROR,
+                     msg='%s: %s %s MiB < %s MiB' % (
+                         store, 'free space under threshold:',
+                         free_space, threshold
+                     ),
+                     store=store, free_space=free_space, threshold=threshold
+                )
+            else:
+                yield Result(
+                     self, constants.SUCCESS,
+                     msg='%s: %s %s MiB >= %s MiB' % (
+                         store, 'free space within limits:',
+                         free_space, threshold
+                     ),
+                     store=store, free_space=free_space, threshold=threshold
+                )

--- a/src/ipahealthcheck/system/plugin.py
+++ b/src/ipahealthcheck/system/plugin.py
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+from ipahealthcheck.core.plugin import Plugin, Registry
+
+
+class SystemPlugin(Plugin):
+    def __init__(self, registry):
+        super(SystemPlugin, self).__init__(registry)
+        pass
+
+
+class SystemRegistry(Registry):
+    def initialize(self, framework):
+        pass
+
+
+registry = SystemRegistry()

--- a/tests/test_system_filesystemspace.py
+++ b/tests/test_system_filesystemspace.py
@@ -1,0 +1,112 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+from base import BaseTest
+from unittest.mock import Mock
+from util import capture_results
+from collections import namedtuple
+
+from ipahealthcheck.core import config, constants
+from ipahealthcheck.system.plugin import registry
+from ipahealthcheck.system.filesystemspace import FileSystemSpaceCheck
+
+
+class TestFileSystemNotEnoughFreeSpace(BaseTest):
+
+    usage = namedtuple('usage', ['total', 'used', 'free'])
+    usage.total = 2087428096
+    usage.used = 1628193914
+    usage.free = 459234182
+
+    patches = {
+        'shutil.disk_usage':
+        Mock(return_value=usage),
+    }
+
+    def test_filesystem_near_enospc(self):
+
+        framework = object()
+        registry.initialize(framework)
+        f = FileSystemSpaceCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        count = 0
+        for result in self.results.results:
+            if result.severity == constants.ERROR:
+                count += 1
+                assert result.source == 'ipahealthcheck.system.filesystemspace'
+                assert result.check == 'FileSystemSpaceCheck'
+                assert 'free space under threshold' in result.kw.get('msg')
+            else:
+                assert 'free space percentage within' in result.kw.get('msg')
+        assert len(self.results) == 10
+        assert count == 5
+
+
+class TestFileSystemNotEnoughFreeSpacePercentage(BaseTest):
+
+    usage = namedtuple('usage', ['total', 'used', 'free'])
+    usage.total = 10437140480
+    usage.used = 8913305600
+    usage.free = 1523834880
+
+    patches = {
+        'shutil.disk_usage':
+        Mock(return_value=usage),
+    }
+
+    def test_filesystem_risking_fragmentation(self):
+
+        framework = object()
+        registry.initialize(framework)
+        f = FileSystemSpaceCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        count = 0
+        for result in self.results.results:
+            if result.severity == constants.ERROR:
+                count += 1
+                assert result.source == 'ipahealthcheck.system.filesystemspace'
+                assert result.check == 'FileSystemSpaceCheck'
+                assert 'free space percentage under' in result.kw.get('msg')
+            else:
+                assert 'free space within limits' in result.kw.get('msg')
+        assert len(self.results) == 10
+        assert count == 5
+
+
+class TestFileSystemEnoughFreeSpace(BaseTest):
+
+    usage = namedtuple('usage', ['total', 'used', 'free'])
+    usage.total = 10437140480
+    usage.used = 1523834880
+    usage.free = 8913305600
+
+    patches = {
+        'shutil.disk_usage':
+        Mock(return_value=usage),
+    }
+
+    def test_filesystem_with_enough_space(self):
+
+        framework = object()
+        registry.initialize(framework)
+        f = FileSystemSpaceCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        for result in self.results.results:
+            assert result.severity == constants.SUCCESS
+            assert result.source == 'ipahealthcheck.system.filesystemspace'
+            assert result.check == 'FileSystemSpaceCheck'
+            assert (
+                'free space percentage within' in result.kw.get('msg') or
+                'free space within limits' in result.kw.get('msg')
+            )
+        assert len(self.results) == 10


### PR DESCRIPTION
The system plugin is meant for operating-system level checks, like
checking for free space in file systems, amount of RAM and swap, etc.

The file system free space check is meant to avoid unfortunate ENOSPC
situations for DS and IPA.