### PR TITLE
Implement AD Trust checking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
             'ipafiles = ipahealthcheck.ipa.files',
             'ipahost = ipahealthcheck.ipa.host',
             'ipatopology = ipahealthcheck.ipa.topology',
+            'ipatrust = ipahealthcheck.ipa.trust',
         ],
         # plugin modules for ipahealthcheck.dogtag registry
         'ipahealthcheck.dogtag': [

--- a/src/ipahealthcheck/ipa/plugin.py
+++ b/src/ipahealthcheck/ipa/plugin.py
@@ -2,7 +2,9 @@
 # Copyright (C) 2019 FreeIPA Contributors see COPYING for license
 #
 
+import logging
 from ipalib import api, errors
+from ipapython.dn import DN
 try:
     from ipapython.ipaldap import realm_to_serverid
 except ImportError:
@@ -12,8 +14,10 @@ from ipaserver.install import dsinstance
 from ipaserver.install import httpinstance
 from ipaserver.install import installutils
 
-
 from ipahealthcheck.core.plugin import Plugin, Registry
+
+
+logging.getLogger()
 
 
 class IPAPlugin(Plugin):
@@ -28,6 +32,11 @@ class IPAPlugin(Plugin):
 
 
 class IPARegistry(Registry):
+    def __init__(self):
+        super(IPARegistry, self).__init__()
+        self.trust_agent = False
+        self.trust_controller = False
+
     def initialize(self, framework):
         installutils.check_server_configuration()
         if not api.isdone('bootstrap'):
@@ -40,10 +49,24 @@ class IPARegistry(Registry):
         if not api.Backend.ldap2.isconnected():
             try:
                 api.Backend.ldap2.connect()
-            except errors.CCacheError:
-                pass
-            except errors.NetworkError:
-                pass
+            except (errors.CCacheError, errors.NetworkError) as e:
+                logging.debug('Failed to connect to LDAP: %s', e)
+            else:
+                # Have to use LDAP because the host principal doesn't have
+                # rights to read server roles.
+                conn = api.Backend.ldap2
+                server_dn = DN(('cn', api.env.host),
+                               api.env.container_masters, api.env.basedn)
+                try:
+                    entry = conn.get_entry(
+                        server_dn,
+                        attrs_list=['enabled_role_servrole'])
+                except Exception as e:
+                    logging.debug('Failed to retrieve IPA master: %s', e)
+                else:
+                    roles = entry.get('enabled_role_servrole', [])
+                    self.trust_agent = 'AD trust agent' in roles
+                    self.trust_controller = 'AD trust controller' in roles
 
 
 registry = IPARegistry()

--- a/src/ipahealthcheck/ipa/trust.py
+++ b/src/ipahealthcheck/ipa/trust.py
@@ -1,0 +1,499 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+import logging
+import os
+import SSSDConfig
+
+from ipahealthcheck.ipa.plugin import IPAPlugin, registry
+from ipahealthcheck.core.plugin import Result
+from ipahealthcheck.core.plugin import duration
+from ipahealthcheck.core import constants
+
+from ipalib import api
+from ipaplatform.paths import paths
+from ipapython import ipautil
+from ipapython.dn import DN
+
+try:
+    from ipaserver.masters import ENABLED_SERVICE
+except ImportError:
+    from ipaserver.install.service import ENABLED_SERVICE
+try:
+    from ipapython.ipaldap import realm_to_serverid
+except ImportError:
+    from ipaserver.install.installutils import realm_to_serverid
+from ipaserver.install.adtrust import retrieve_netbios_name
+from ipaserver.install.adtrustinstance import make_netbios_name
+
+logger = logging.getLogger()
+
+
+def get_trust_domains():
+    """
+    Get the list of AD trust domains from IPA
+
+    The caller is expected to catch any exceptions.
+    """
+    result = api.Command.trust_find()
+    results = result['result']
+    trust_domains = []
+    for result in results:
+        if result.get('trusttype')[0] == 'Active Directory domain':
+            trust_domains.append(result.get('cn')[0])
+    return trust_domains
+
+
+@registry
+class IPATrustAgentCheck(IPAPlugin):
+    """
+    Check the values that should be set when configures as a trust agent.
+    """
+    @duration
+    def check(self):
+        if not self.registry.trust_agent:
+            logger.debug('Not a trust agent, skipping')
+            return
+
+        try:
+            sssdconfig = SSSDConfig.SSSDConfig()
+            sssdconfig.import_config()
+        except Exception as e:
+            logger.debug('Failed to parse sssd.conf: %s', e)
+            yield Result(self, constants.CRITICAL, error=str(e),
+                         msg='Unable to parse sssd.conf: {error}')
+            return
+        else:
+            domains = sssdconfig.list_active_domains()
+
+        errors = False
+        for name in domains:
+            domain = sssdconfig.get_domain(name)
+            try:
+                provider = domain.get_option('id_provider')
+            except SSSDConfig.NoOptionError:
+                continue
+            if provider == "ipa":
+                try:
+                    mode = domain.get_option('ipa_server_mode')
+                except SSSDConfig.NoOptionError:
+                    yield Result(self, constants.ERROR,
+                                 key='ipa_server_mode_missing',
+                                 attr='ipa_server_mode',
+                                 domain=name,
+                                 sssd_config=paths.SSSD_CONF,
+                                 msg='{sssd_config} is missing {attr} '
+                                     'in the domain {domain}')
+                    errors = True
+                else:
+                    if not mode:
+                        yield Result(self, constants.ERROR,
+                                     key='ipa_server_mode_false',
+                                     attr='ipa_server_mode',
+                                     domain=name,
+                                     sssd_config=paths.SSSD_CONF,
+                                     msg='{attr} is not True in {sssd_config} '
+                                         'in the domain {domain}')
+                        errors = True
+
+            if not errors:
+                yield Result(self, constants.SUCCESS)
+
+
+@registry
+class IPATrustDomainsCheck(IPAPlugin):
+    """
+    Check the trust domains
+    """
+    @duration
+    def check(self):
+        if not self.registry.trust_agent:
+            logger.debug('Not a trust agent, skipping')
+            return
+
+        result = ipautil.run([paths.SSSCTL, "domain-list"], raiseonerr=False,
+                             capture_output=True)
+        if result.returncode != 0:
+            yield Result(self, constants.ERROR,
+                         key='domain_list_error',
+                         sslctl=paths.SSSCTL,
+                         error=result.error_log,
+                         msg='Execution of {sslctl} failed: {error}')
+            return
+        sssd_domains = result.output.strip().split('\n')
+        if 'implicit_files' not in sssd_domains:
+            yield Result(self, constants.WARNING,
+                         key='implicit_files',
+                         sslctl=paths.SSSCTL,
+                         msg='{key} not in {sslctl} output')
+        else:
+            sssd_domains.remove('implicit_files')
+
+        try:
+            trust_domains = get_trust_domains()
+        except Exception as e:
+            yield Result(self, constants.WARNING,
+                         key='trust-find',
+                         error=str(e),
+                         msg='Execution of {key} failed: {error}')
+            trust_domains = []
+
+        if api.env.domain in sssd_domains:
+            sssd_domains.remove(api.env.domain)
+        else:
+            yield Result(self, constants.ERROR,
+                         key=api.env.domain,
+                         sslctl=paths.SSSCTL,
+                         msg='{key} not in {sslctl} domain-list')
+
+        trust_domains_out = ', '.join(trust_domains)
+        sssd_domains_out = ', '.join(sssd_domains)
+
+        if set(trust_domains).symmetric_difference(set(sssd_domains)):
+            yield Result(self, constants.ERROR,
+                         key='domain-list',
+                         sslctl=paths.SSSCTL,
+                         sssd_domains=sssd_domains_out,
+                         trust_domains=trust_domains_out,
+                         msg='{sslctl} {key} reports mismatch: '
+                         'sssd domains {sssd_domains} '
+                         'trust domains {trust_domains}')
+        else:
+            yield Result(self, constants.SUCCESS,
+                         key='domain-list',
+                         sssd_domains=sssd_domains_out,
+                         trust_domains=trust_domains_out)
+
+        for domain in sssd_domains:
+            args = [paths.SSSCTL, "domain-status", domain, "--online"]
+            try:
+                result = ipautil.run(args, capture_output=True)
+            except Exception as e:
+                yield Result(self, constants.WARNING,
+                             key='domain-status',
+                             error=str(e),
+                             msg='Execution of {key} failed: {error}')
+                continue
+            else:
+                if result.output.strip() != 'Online status: Online':
+                    yield Result(self, constants.WARNING,
+                                 key='domain-status',
+                                 domain=domain,
+                                 msg='Domain {domain} is not online')
+                else:
+                    yield Result(self, constants.SUCCESS,
+                                 key='domain-status',
+                                 domain=domain)
+
+
+@registry
+class IPATrustCatalogCheck(IPAPlugin):
+    """
+    Resolve an AD user
+
+    This should populate the 'AD Global catalog' and 'AD Domain Controller'
+    fields in 'sssctl domain-status' output (means SSSD actually talks to AD
+    DCs)
+    """
+    @duration
+    def check(self):
+        if not self.registry.trust_agent:
+            logger.debug('Not a trust agent, skipping')
+            return
+
+        try:
+            trust_domains = get_trust_domains()
+        except Exception as e:
+            yield Result(self, constants.WARNING,
+                         key='trust-find',
+                         error=str(e),
+                         msg='Execution of {key} failed: {error}')
+            trust_domains = []
+
+        for domain in trust_domains:
+            try:
+                ipautil.run(['/bin/id', "Administrator@%s" % domain],
+                            capture_output=True)
+            except Exception as e:
+                yield Result(self, constants.WARNING,
+                             key='/bin/id',
+                             error=str(e),
+                             msg='Execution of {key} failed: {error}')
+                continue
+
+            args = [paths.SSSCTL, "domain-status", domain, "--active-server"]
+            try:
+                result = ipautil.run(args, capture_output=True)
+            except Exception as e:
+                yield Result(self, constants.ERROR,
+                             key='domain-status',
+                             error=str(e),
+                             msg='Execution of {key} failed: {error}')
+                continue
+            else:
+                for txt in ['AD Global Catalog', 'AD Domain Controller']:
+                    if txt not in result.output:
+                        yield Result(self, constants.ERROR,
+                                     key=txt,
+                                     output=result.output.strip(),
+                                     sssctl=paths.SSSCTL,
+                                     domain=domain,
+                                     msg='{key} not found in {sssctl} '
+                                     '\'domain-status\' output: {output}')
+                    else:
+                        yield Result(self, constants.SUCCESS,
+                                     key=txt,
+                                     domain=domain)
+
+
+@registry
+class IPAsidgenpluginCheck(IPAPlugin):
+    """
+    Verify that the sidgen 389-ds plugins are enabled
+    """
+    @duration
+    def check(self):
+        if not self.registry.trust_agent:
+            logger.debug('Not a trust agent, skipping')
+            return
+
+        for plugin in ['IPA SIDGEN', 'ipa-sidgen-task']:
+            sidgen_dn = DN(('cn', plugin), "cn=plugins,cn=config")
+            try:
+                entry = self.conn.get_entry(
+                    sidgen_dn,
+                    attrs_list=['nsslapd-pluginEnabled'])
+            except Exception as e:
+                yield Result(self, constants.ERROR,
+                             key=plugin,
+                             error=str(e),
+                             msg='Error retrieving 389-ds plugin {key}: '
+                             '{error}')
+            else:
+                enabled = entry.get('nsslapd-pluginEnabled', [])
+                if len(enabled) != 1:
+                    yield Result(self, constants.ERROR,
+                                 key=plugin,
+                                 dn=str(sidgen_dn),
+                                 attr=enabled,
+                                 msg='{key}: unexpected value in '
+                                 'nsslapd-pluginEnabled in entry {dn}'
+                                 '{attr}')
+                    continue
+                if entry.get('nsslapd-pluginEnabled', [])[0].lower() != 'on':
+                    yield Result(self, constants.ERROR,
+                                 key=plugin,
+                                 msg='389-ds plugin {key} is not enabled')
+                else:
+                    yield Result(self, constants.SUCCESS,
+                                 key=plugin)
+
+
+@registry
+class IPATrustAgentMemberCheck(IPAPlugin):
+    """
+    Verify that the current host is a member of adtrust agents
+    """
+    @duration
+    def check(self):
+        if not self.registry.trust_agent:
+            logger.debug('Not a trust agent, skipping')
+            return
+
+        agent_dn = DN(('fqdn', api.env.host), api.env.container_host,
+                      api.env.basedn)
+        group_dn = DN(('cn', 'adtrust agents'), api.env.container_sysaccounts,
+                      api.env.basedn)
+        try:
+            entry = self.conn.get_entry(
+                agent_dn,
+                attrs_list=['memberOf'])
+        except Exception as e:
+            yield Result(self, constants.ERROR,
+                         key=str(agent_dn),
+                         error=str(e),
+                         msg='Error retrieving ldap entry {key}: '
+                         '{error}')
+        else:
+            memberof = entry.get('memberof', [])
+            for member in memberof:
+                if DN(member) == group_dn:
+                    yield Result(self, constants.SUCCESS,
+                                 key=api.env.host)
+                    return
+
+            yield Result(self, constants.ERROR,
+                         key=api.env.host,
+                         group='adtrust agents',
+                         msg='{key} is not a member of {group}')
+
+
+@registry
+class IPATrustControllerPrincipalCheck(IPAPlugin):
+    """
+    Verify that the current host cifs principal is a member of adtrust agents
+    """
+    @duration
+    def check(self):
+        if not self.registry.trust_controller:
+            logger.debug('Not a trust controller, skipping')
+            return
+
+        agent_dn = DN(('krbprincipalname',
+                      'cifs/%s@%s' % (api.env.host, api.env.realm)),
+                      api.env.container_service, api.env.basedn)
+        group_dn = DN(('cn', 'adtrust agents'), api.env.container_sysaccounts,
+                      api.env.basedn)
+        try:
+            entry = self.conn.get_entry(
+                agent_dn,
+                attrs_list=['memberOf'])
+        except Exception as e:
+            yield Result(self, constants.ERROR,
+                         key=str(agent_dn),
+                         error=str(e),
+                         msg='Error retrieving ldap entry {key}: '
+                         '{error}')
+        else:
+            memberof = entry.get('memberof', [])
+            for member in memberof:
+                if DN(member) == group_dn:
+                    yield Result(self, constants.SUCCESS,
+                                 key='cifs/%s@%s' %
+                                 (api.env.host, api.env.realm))
+                    return
+
+            yield Result(self, constants.ERROR,
+                         key='cifs/%s@%s' % (api.env.host, api.env.realm),
+                         group='adtrust agents',
+                         msg='{key} is not a member of {group}')
+
+
+@registry
+class IPATrustControllerServiceCheck(IPAPlugin):
+    """
+    Verify that the current host starts the ADTRUST service.
+    """
+    @duration
+    def check(self):
+        if not self.registry.trust_controller:
+            logger.debug('Not a trust controller, skipping')
+            return
+
+        service_dn = DN(('cn', 'ADTRUST'), ('cn', api.env.host),
+                        api.env.container_masters, api.env.basedn)
+
+        try:
+            entry = self.conn.get_entry(
+                service_dn,
+                attrs_list=['ipaconfigstring'])
+        except Exception as e:
+            yield Result(self, constants.ERROR,
+                         key=str(service_dn),
+                         error=str(e),
+                         msg='Error retrieving ldap entry {key}: '
+                         '{error}')
+        else:
+            configs = entry.get('ipaconfigstring', [])
+            enabled = False
+            for config in configs:
+                if config == ENABLED_SERVICE:
+                    enabled = True
+                    break
+
+            if enabled:
+                yield Result(self, constants.SUCCESS,
+                             key='ADTRUST')
+            else:
+                yield Result(self, constants.ERROR,
+                             key='ADTRUST',
+                             msg='{key} service is not enabled')
+
+
+@registry
+class IPATrustControllerConfCheck(IPAPlugin):
+    """
+    Verify that smb.conf matches the template
+    """
+    @duration
+    def check(self):
+        if not self.registry.trust_controller:
+            logger.debug('Not a trust controller, skipping')
+            return
+
+        netbios_name = retrieve_netbios_name(api)
+        host_netbios_name = make_netbios_name(api.env.host)
+        ldapi_socket = "%%2fvar%%2frun%%2fslapd-%s.socket" % \
+                       realm_to_serverid(api.env.realm)
+
+        sub_dict = dict(REALM=api.env.realm,
+                        SUFFIX=api.env.basedn,
+                        NETBIOS_NAME=netbios_name,
+                        HOST_NETBIOS_NAME=host_netbios_name,
+                        LDAPI_SOCKET=ldapi_socket)
+
+        template = os.path.join(paths.USR_SHARE_IPA_DIR, "smb.conf.template")
+        expected_conf = ipautil.template_file(template, sub_dict)
+
+        try:
+            result = ipautil.run(['net', 'conf', 'list'], capture_output=True)
+        except Exception as e:
+            yield Result(self, constants.ERROR,
+                         key='net_conf_list',
+                         error=str(e),
+                         msg='Execution of {key} failed: {error}')
+        else:
+            conf = result.output.replace('\n', '')
+            conf = conf.replace('\t', '')
+            conf = conf.replace(' ', '')
+            expected_conf = expected_conf.replace('\n', '')
+            expected_conf = expected_conf.replace(' ', '')
+
+            if conf != expected_conf:
+                yield Result(self, constants.ERROR,
+                             key='net_conf_list',
+                             template=template,
+                             msg='net conf list output doesn\'t match '
+                             '{template}')
+            else:
+                yield Result(self, constants.SUCCESS,
+                             key='net_conf_list')
+
+
+@registry
+class IPATrustControllerGroupSIDCheck(IPAPlugin):
+    """
+    Verify that the admins group's SID ends with 512 (Domain Admins RID)
+    """
+    @duration
+    def check(self):
+        if not self.registry.trust_controller:
+            logger.debug('Not a trust controller, skipping')
+            return
+
+        admins_dn = DN(('cn', 'admins'),
+                       api.env.container_group, api.env.basedn)
+
+        try:
+            entry = self.conn.get_entry(
+                admins_dn,
+                attrs_list=['ipantsecurityidentifier'])
+        except Exception as e:
+            yield Result(self, constants.ERROR,
+                         key=str(admins_dn),
+                         error=str(e),
+                         msg='Error retrieving ldap entry {key}: '
+                         '{error}')
+            return
+
+        identifier = entry.get('ipantsecurityidentifier', [None])[0]
+        if not identifier or not identifier.endswith('512'):
+            yield Result(self, constants.ERROR,
+                         key='ipantsecurityidentifier',
+                         rid=identifier,
+                         msg='{key} is not a Domain Admins RID')
+        else:
+            yield Result(self, constants.SUCCESS,
+                         rid=identifier,
+                         key='ipantsecurityidentifier')

--- a/tests/test_ds_replication.py
+++ b/tests/test_ds_replication.py
@@ -72,7 +72,7 @@ class TestReplicationConflicts(BaseTest):
             objectclass=['top']
         )
         fake_conn = LDAPClient('ldap://localhost', no_schema=True)
-        ldapentry = LDAPEntry(fake_conn, DN('cn=conflict', m_api.env.domain))
+        ldapentry = LDAPEntry(fake_conn, DN('cn=conflict', m_api.env.basedn))
         for attr, values in attrs.items():
             ldapentry[attr] = values
         mock_conn.return_value = mock_ldap([ldapentry])

--- a/tests/test_ipa_trust.py
+++ b/tests/test_ipa_trust.py
@@ -1,0 +1,890 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+from base import BaseTest
+from collections import namedtuple
+from unittest.mock import Mock, patch
+from util import capture_results
+from util import m_api
+
+from ipahealthcheck.core import config, constants
+from ipahealthcheck.ipa.plugin import registry
+from ipahealthcheck.ipa.trust import (IPATrustAgentCheck,
+                                      IPATrustDomainsCheck,
+                                      IPATrustCatalogCheck,
+                                      IPAsidgenpluginCheck,
+                                      IPATrustAgentMemberCheck,
+                                      IPATrustControllerPrincipalCheck,
+                                      IPATrustControllerServiceCheck,
+                                      IPATrustControllerGroupSIDCheck)
+
+from ipalib import errors
+from ipapython.dn import DN
+from ipapython.ipaldap import LDAPClient, LDAPEntry
+
+from ldap import OPT_X_SASL_SSF_MIN
+from SSSDConfig import NoOptionError
+
+
+class mock_ldap:
+    SCOPE_BASE = 1
+    SCOPE_ONELEVEL = 2
+    SCOPE_SUBTREE = 4
+
+    def __init__(self, ldapentry):
+        """Initialize the results that we will return from get_entries"""
+        self.results = ldapentry
+
+#    def get_entries(self, base_dn, scope=SCOPE_SUBTREE, filter=None,
+#                    attrs_list=None, get_effective_rights=False, **kwargs):
+#        if self.results is None:
+#            raise errors.NotFound(reason='test')
+#        return self.results
+    def get_entry(self, dn, attrs_list=None, time_limit=None,
+                  size_limit=None, get_effective_rights=False):
+        if self.results is None:
+            raise errors.NotFound(reason='test')
+        return self.results
+
+
+class mock_ldap_conn:
+    def set_option(self, option, invalue):
+        pass
+
+    def get_option(self, option):
+        if option == OPT_X_SASL_SSF_MIN:
+            return 256
+
+    def search_s(self, base, scope, filterstr=None,
+                 attrlist=None, attrsonly=0):
+        return tuple()
+
+
+class SSSDDomain:
+    def __init__(self, return_ipa_server_mode):
+        self.return_ipa_server_mode = return_ipa_server_mode
+
+    def get_option(self, option):
+        if option == 'id_provider':
+            return 'ipa'
+        elif option == 'ipa_server_mode':
+            if self.return_ipa_server_mode is None:
+                raise NoOptionError()
+            return self.return_ipa_server_mode
+
+
+class SSSDConfig():
+    def __init__(self, return_domains, return_ipa_server_mode):
+        """
+        Knobs to control what data the configuration returns.
+        """
+        self.return_domains = return_domains
+        self.return_ipa_server_mode = return_ipa_server_mode
+
+    def import_config(self):
+        pass
+
+    def list_active_domains(self):
+        return ('ipa.example',)
+
+    def get_domain(self, name):
+        return SSSDDomain(self.return_ipa_server_mode)
+
+
+class TestTrustAgent(BaseTest):
+    patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        Mock(return_value=None),
+    }
+
+    def test_no_trust_agent(self):
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = False
+        f = IPATrustAgentCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        # Zero because the call was skipped altogether
+        assert len(self.results) == 0
+
+    @patch('SSSDConfig.SSSDConfig')
+    def test_trust_agent_ok(self, mock_sssd):
+        mock_sssd.return_value = SSSDConfig(return_domains=True,
+                                            return_ipa_server_mode=True)
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPATrustAgentCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustAgentCheck'
+
+    @patch('SSSDConfig.SSSDConfig')
+    def test_trust_agent_not_ipa(self, mock_sssd):
+        mock_sssd.return_value = SSSDConfig(return_domains=True,
+                                            return_ipa_server_mode=False)
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPATrustAgentCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.ERROR
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustAgentCheck'
+        assert result.kw.get('key') == 'ipa_server_mode_false'
+        assert result.kw.get('domain') == 'ipa.example'
+
+    @patch('SSSDConfig.SSSDConfig')
+    def test_trust_agent_fail(self, mock_sssd):
+        mock_sssd.return_value = SSSDConfig(return_domains=True,
+                                            return_ipa_server_mode=None)
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPATrustAgentCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.ERROR
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustAgentCheck'
+        assert result.kw.get('key') == 'ipa_server_mode_missing'
+        assert result.kw.get('domain') == 'ipa.example'
+
+
+class TestTrustDomains(BaseTest):
+    patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        Mock(return_value=None),
+    }
+
+    def test_no_trust_agent(self):
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = False
+        f = IPATrustDomainsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        # Zero because the call was skipped altogether
+        assert len(self.results) == 0
+
+    @patch('ipapython.ipautil.run')
+    def test_trust_domain_list_fail(self, mock_run):
+        run_result = namedtuple('run', ['returncode', 'error_log'])
+        run_result.returncode = 1
+        run_result.error_log = 'error'
+        mock_run.return_value = run_result
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPATrustDomainsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.ERROR
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustDomainsCheck'
+        assert result.kw.get('key') == 'domain_list_error'
+
+    @patch('ipapython.ipautil.run')
+    def test_trust_domain_list_no_implicit_files(self, mock_run):
+        run_result = namedtuple('run', ['returncode', 'error_log'])
+        run_result.returncode = 0
+        run_result.error_log = ''
+        run_result.output = 'ipa.example\nad.example\n'
+        mock_run.return_value = run_result
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPATrustDomainsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        # There are more than one result I just care about this particular
+        # value. The error is not fatal.
+        result = self.results.results[0]
+        assert result.severity == constants.WARNING
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustDomainsCheck'
+        assert result.kw.get('key') == 'implicit_files'
+
+    @patch('ipapython.ipautil.run')
+    @patch('ipahealthcheck.ipa.trust.get_trust_domains')
+    def test_trust_get_trust_domains_fail(self, mock_trust, mock_run):
+        # sssctl domain-list
+        run_result = namedtuple('run', ['returncode', 'error_log'])
+        run_result.returncode = 0
+        run_result.error_log = ''
+        run_result.output = 'implicit_files\nipa.example\nad.example\n'
+        mock_run.return_value = run_result
+
+        mock_trust.side_effect = errors.NotFound(reason='bad')
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPATrustDomainsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        # There are more than one result I just care about this particular
+        # value. The error is not fatal.
+        result = self.results.results[0]
+        assert result.severity == constants.WARNING
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustDomainsCheck'
+        assert result.kw.get('key') == 'trust-find'
+
+    @patch('ipapython.ipautil.run')
+    def test_trust_get_trust_domains_ok(self, mock_run):
+        # sssctl domain-list
+        dlresult = namedtuple('run', ['returncode', 'error_log'])
+        dlresult.returncode = 0
+        dlresult.error_log = ''
+        dlresult.output = 'implicit_files\nipa.example\nad.example\n' \
+            'child.example\n'
+        olresult = namedtuple('run', ['returncode', 'error_log'])
+        olresult.returncode = 0
+        olresult.error_log = ''
+        olresult.output = 'Online status: Online\n\n'
+
+        mock_run.side_effect = [dlresult, olresult, olresult]
+
+        # get_trust_domains()
+        m_api.Command.trust_find.side_effect = [{
+            'result': [
+                {
+                    'cn': ['ad.example'],
+                    'ipantflatname': ['ADROOT'],
+                    "trusttype": ["Active Directory domain"],
+                },
+                {
+                    'cn': ['child.example'],
+                    'ipantflatname': ['ADROOT'],
+                    "trusttype": ["Active Directory domain"],
+                },
+            ]
+        }]
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPATrustDomainsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 3
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustDomainsCheck'
+        assert result.kw.get('key') == 'domain-list'
+        assert result.kw.get('trust_domains') == 'ad.example, child.example'
+        assert result.kw.get('sssd_domains') == 'ad.example, child.example'
+
+        result = self.results.results[1]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustDomainsCheck'
+        assert result.kw.get('key') == 'domain-status'
+        assert result.kw.get('domain') == 'ad.example'
+
+        result = self.results.results[2]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustDomainsCheck'
+        assert result.kw.get('key') == 'domain-status'
+        assert result.kw.get('domain') == 'child.example'
+
+    @patch('ipapython.ipautil.run')
+    def test_trust_get_trust_domains_mismatch(self, mock_run):
+        # sssctl domain-list
+        dlresult = namedtuple('run', ['returncode', 'error_log'])
+        dlresult.returncode = 0
+        dlresult.error_log = ''
+        dlresult.output = 'implicit_files\nipa.example\n' \
+            'child.example\n'
+        olresult = namedtuple('run', ['returncode', 'error_log'])
+        olresult.returncode = 0
+        olresult.error_log = ''
+        olresult.output = 'Online status: Online\n\n'
+
+        mock_run.side_effect = [dlresult, olresult, olresult]
+
+        # get_trust_domains()
+        m_api.Command.trust_find.side_effect = [{
+            'result': [
+                {
+                    'cn': ['ad.example'],
+                    'ipantflatname': ['ADROOT'],
+                    "trusttype": ["Active Directory domain"],
+                },
+                {
+                    'cn': ['child.example'],
+                    'ipantflatname': ['ADROOT'],
+                    "trusttype": ["Active Directory domain"],
+                },
+            ]
+        }]
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPATrustDomainsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+
+        result = self.results.results[0]
+        assert result.severity == constants.ERROR
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustDomainsCheck'
+        assert result.kw.get('key') == 'domain-list'
+        assert result.kw.get('trust_domains') == 'ad.example, child.example'
+        assert result.kw.get('sssd_domains') == 'child.example'
+
+        result = self.results.results[1]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustDomainsCheck'
+        assert result.kw.get('key') == 'domain-status'
+        assert result.kw.get('domain') == 'child.example'
+
+
+class TestTrustCatalog(BaseTest):
+    patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        Mock(return_value=None),
+    }
+
+    def test_no_trust_agent(self):
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = False
+        f = IPATrustCatalogCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        # Zero because the call was skipped altogether
+        assert len(self.results) == 0
+
+    @patch('ipapython.ipautil.run')
+    def test_trust_catalog_ok(self, mock_run):
+        # id Administrator@ad.example
+        idresult = namedtuple('run', ['returncode', 'error_log'])
+        idresult.returncode = 0
+        idresult.error_log = ''
+        idresult.output = '797600500(administrator@ad.example),' \
+            '1797600520(group policy creator owners@ad.example),' \
+            '1797600519(enterprise admins@ad.example),' \
+            '1797600512(domain admins@ad.example),' \
+            '1797600518(schema admins@ad.example)' \
+            ',1797600513(domain users@ad.example)\n'
+        dsresult = namedtuple('run', ['returncode', 'error_log'])
+        dsresult.returncode = 0
+        dsresult.error_log = ''
+        dsresult.output = 'Active servers:\nAD Global Catalog: ' \
+            'root-dc.ad.vm\nAD Domain Controller: root-dc.ad.vm\n' \
+            'IPA: master.ipa.vm\n\n'
+        # id Administrator@client.example
+        id2result = namedtuple('run', ['returncode', 'error_log'])
+        id2result.returncode = 0
+        id2result.error_log = ''
+        id2result.output = '797600500(administrator@client.example),' \
+            '1797600520(group policy creator owners@client.example),' \
+            '1797600519(enterprise admins@client.example),' \
+            '1797600512(domain admins@client.example),' \
+            '1797600518(schema admins@client.example)' \
+            ',1797600513(domain users@client.example)\n'
+        ds2result = namedtuple('run', ['returncode', 'error_log'])
+        ds2result.returncode = 0
+        ds2result.error_log = ''
+        ds2result.output = 'Active servers:\nAD Global Catalog: ' \
+            'root-dc.ad.vm\nAD Domain Controller: root-dc.ad.vm\n' \
+
+        mock_run.side_effect = [idresult, dsresult, id2result, ds2result]
+
+        # get_trust_domains()
+        m_api.Command.trust_find.side_effect = [{
+            'result': [
+                {
+                    'cn': ['ad.example'],
+                    'ipantflatname': ['ADROOT'],
+                    "trusttype": ["Active Directory domain"],
+                },
+                {
+                    'cn': ['child.example'],
+                    'ipantflatname': ['ADROOT'],
+                    "trusttype": ["Active Directory domain"],
+                },
+            ]
+        }]
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPATrustCatalogCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 4
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustCatalogCheck'
+        assert result.kw.get('key') == 'AD Global Catalog'
+
+        result = self.results.results[1]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustCatalogCheck'
+        assert result.kw.get('key') == 'AD Domain Controller'
+
+        result = self.results.results[2]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustCatalogCheck'
+        assert result.kw.get('key') == 'AD Global Catalog'
+
+        result = self.results.results[1]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustCatalogCheck'
+        assert result.kw.get('key') == 'AD Domain Controller'
+
+
+class Testsidgen(BaseTest):
+    patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        Mock(return_value=None),
+        'ldap.initialize':
+        Mock(return_value=mock_ldap_conn()),
+    }
+
+    def test_no_trust_agent(self):
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = False
+        f = IPAsidgenpluginCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        # Zero because the call was skipped altogether
+        assert len(self.results) == 0
+
+    def test_sidgen_ok(self):
+        attrs = {
+            'nsslapd-pluginEnabled': ['on'],
+        }
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        ldapentry = LDAPEntry(fake_conn, DN('cn=plugin, cn=config'))
+        for attr, values in attrs.items():
+            ldapentry[attr] = values
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPAsidgenpluginCheck(registry)
+
+        f.conn = mock_ldap(ldapentry)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPAsidgenpluginCheck'
+        assert result.kw.get('key') == 'IPA SIDGEN'
+
+        result = self.results.results[1]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPAsidgenpluginCheck'
+        assert result.kw.get('key') == 'ipa-sidgen-task'
+
+    def test_sidgen_fail(self):
+        attrs = {
+            'nsslapd-pluginEnabled': ['off'],
+        }
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        ldapentry = LDAPEntry(fake_conn, DN('cn=plugin, cn=config'))
+        for attr, values in attrs.items():
+            ldapentry[attr] = values
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPAsidgenpluginCheck(registry)
+
+        f.conn = mock_ldap(ldapentry)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+
+        result = self.results.results[0]
+        assert result.severity == constants.ERROR
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPAsidgenpluginCheck'
+        assert result.kw.get('key') == 'IPA SIDGEN'
+
+        result = self.results.results[1]
+        assert result.severity == constants.ERROR
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPAsidgenpluginCheck'
+        assert result.kw.get('key') == 'ipa-sidgen-task'
+
+
+class TestTrustAgentMember(BaseTest):
+    patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        Mock(return_value=None),
+        'ldap.initialize':
+        Mock(return_value=mock_ldap_conn()),
+    }
+
+    def test_no_trust_agent(self):
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = False
+        f = IPATrustAgentMemberCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        # Zero because the call was skipped altogether
+        assert len(self.results) == 0
+
+    def test_member_ok(self):
+        agent_dn = DN(('fqdn', m_api.env.host), m_api.env.container_host,
+                      m_api.env.basedn)
+        group_dn = DN(('cn', 'adtrust agents'),
+                      m_api.env.container_sysaccounts,
+                      m_api.env.basedn)
+        attrs = {
+            'memberof': [group_dn],
+        }
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        ldapentry = LDAPEntry(fake_conn, agent_dn)
+        for attr, values in attrs.items():
+            ldapentry[attr] = values
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPATrustAgentMemberCheck(registry)
+
+        f.conn = mock_ldap(ldapentry)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustAgentMemberCheck'
+        assert result.kw.get('key') == m_api.env.host
+
+    def test_member_fail(self):
+        agent_dn = DN(('fqdn', m_api.env.host), m_api.env.container_host,
+                      m_api.env.basedn)
+        attrs = {
+            'memberof': [agent_dn],
+        }
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        ldapentry = LDAPEntry(fake_conn, agent_dn)
+        for attr, values in attrs.items():
+            ldapentry[attr] = values
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_agent = True
+        f = IPATrustAgentMemberCheck(registry)
+
+        f.conn = mock_ldap(ldapentry)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.ERROR
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustAgentMemberCheck'
+        assert result.kw.get('key') == m_api.env.host
+
+
+class TestControllerPrincipal(BaseTest):
+    patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        Mock(return_value=None),
+        'ldap.initialize':
+        Mock(return_value=mock_ldap_conn()),
+    }
+
+    def test_not_trust_controller(self):
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_controller = False
+        f = IPATrustControllerPrincipalCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        # Zero because the call was skipped altogether
+        assert len(self.results) == 0
+
+    def test_principal_ok(self):
+        agent_dn = DN(('krbprincipalname',
+                      'cifs/%s@%s' % (m_api.env.host, m_api.env.realm)),
+                      m_api.env.container_service, m_api.env.basedn)
+        group_dn = DN(('cn', 'adtrust agents'),
+                      m_api.env.container_sysaccounts,
+                      m_api.env.basedn)
+        attrs = {
+            'memberof': [group_dn],
+        }
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        ldapentry = LDAPEntry(fake_conn, agent_dn)
+        for attr, values in attrs.items():
+            ldapentry[attr] = values
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_controller = True
+        f = IPATrustControllerPrincipalCheck(registry)
+
+        f.conn = mock_ldap(ldapentry)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustControllerPrincipalCheck'
+        assert result.kw.get('key') == 'cifs/%s@%s' % \
+                                       (m_api.env.host, m_api.env.realm)
+
+    def test_member_fail(self):
+        agent_dn = DN(('fqdn', m_api.env.host), m_api.env.container_host,
+                      m_api.env.basedn)
+        attrs = {
+            'memberof': [agent_dn],
+        }
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        ldapentry = LDAPEntry(fake_conn, agent_dn)
+        for attr, values in attrs.items():
+            ldapentry[attr] = values
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_controller = True
+        f = IPATrustControllerPrincipalCheck(registry)
+
+        f.conn = mock_ldap(ldapentry)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.ERROR
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.kw.get('key') == 'cifs/%s@%s' % \
+                                       (m_api.env.host, m_api.env.realm)
+
+
+class TestControllerService(BaseTest):
+    patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        Mock(return_value=None),
+        'ldap.initialize':
+        Mock(return_value=mock_ldap_conn()),
+    }
+
+    def test_not_trust_controller(self):
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_controller = False
+        f = IPATrustControllerServiceCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        # Zero because the call was skipped altogether
+        assert len(self.results) == 0
+
+    def test_principal_ok(self):
+        service_dn = DN(('cn', 'ADTRUST'))
+        attrs = {
+            'ipaconfigstring': ['enabledService'],
+        }
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        ldapentry = LDAPEntry(fake_conn, service_dn)
+        for attr, values in attrs.items():
+            ldapentry[attr] = values
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_controller = True
+        f = IPATrustControllerServiceCheck(registry)
+
+        f.conn = mock_ldap(ldapentry)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustControllerServiceCheck'
+        assert result.kw.get('key') == 'ADTRUST'
+
+    def test_principal_fail(self):
+        service_dn = DN(('cn', 'ADTRUST'))
+        attrs = {
+            'ipaconfigstring': ['disabledService'],
+        }
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        ldapentry = LDAPEntry(fake_conn, service_dn)
+        for attr, values in attrs.items():
+            ldapentry[attr] = values
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_controller = True
+        f = IPATrustControllerServiceCheck(registry)
+
+        f.conn = mock_ldap(ldapentry)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.ERROR
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.kw.get('key') == 'ADTRUST'
+
+
+class TestControllerGroupSID(BaseTest):
+    patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        Mock(return_value=None),
+        'ldap.initialize':
+        Mock(return_value=mock_ldap_conn()),
+    }
+
+    def test_not_trust_controller(self):
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_controller = False
+        f = IPATrustControllerGroupSIDCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        # Zero because the call was skipped altogether
+        assert len(self.results) == 0
+
+    def test_principal_ok(self):
+        admins_dn = DN(('cn', 'admins'))
+        attrs = {
+            'ipantsecurityidentifier':
+            ['S-1-5-21-1234-5678-1976041503-512'],
+        }
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        ldapentry = LDAPEntry(fake_conn, admins_dn)
+        for attr, values in attrs.items():
+            ldapentry[attr] = values
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_controller = True
+        f = IPATrustControllerGroupSIDCheck(registry)
+
+        f.conn = mock_ldap(ldapentry)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustControllerGroupSIDCheck'
+        assert result.kw.get('key') == 'ipantsecurityidentifier'
+        assert result.kw.get('rid') == 'S-1-5-21-1234-5678-1976041503-512'
+
+    def test_principal_fail(self):
+        admins_dn = DN(('cn', 'admins'))
+        attrs = {
+            'ipantsecurityidentifier':
+            ['S-1-5-21-1234-5678-1976041503-500'],
+        }
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        ldapentry = LDAPEntry(fake_conn, admins_dn)
+        for attr, values in attrs.items():
+            ldapentry[attr] = values
+
+        framework = object()
+        registry.initialize(framework)
+        registry.trust_controller = True
+        f = IPATrustControllerGroupSIDCheck(registry)
+
+        f.conn = mock_ldap(ldapentry)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.ERROR
+        assert result.source == 'ipahealthcheck.ipa.trust'
+        assert result.check == 'IPATrustControllerGroupSIDCheck'
+        assert result.kw.get('key') == 'ipantsecurityidentifier'
+        assert result.kw.get('rid') == 'S-1-5-21-1234-5678-1976041503-500'

--- a/tests/util.py
+++ b/tests/util.py
@@ -5,6 +5,7 @@
 from ipahealthcheck.core.plugin import Results
 from unittest.mock import patch, Mock
 import ipalib
+from ipapython.dn import DN
 
 
 class ExceptionNotRaised(Exception):
@@ -78,9 +79,16 @@ p_api = patch('ipalib.api', autospec=ipalib.api)
 m_api = p_api.start()
 m_api.isdone.return_value = False
 m_api.env = Mock()
+m_api.env.host = 'server.ipa.example'
 m_api.env.server = 'server.ipa.example'
 m_api.env.realm = u'IPA.EXAMPLE'
-m_api.env.domain = u'dc=ipa,dc=example'
+m_api.env.domain = u'ipa.example'
+m_api.env.basedn = u'dc=ipa,dc=example'
+m_api.env.container_group = DN(('cn', 'groups'), ('cn', 'accounts'))
+m_api.env.container_host = DN(('cn', 'computers'), ('cn', 'accounts'))
+m_api.env.container_sysaccounts = DN(('cn', 'sysaccounts'), ('cn', 'etc'))
+m_api.env.container_service = DN(('cn', 'services'), ('cn', 'accounts'))
+m_api.env.container_masters = DN(('cn', 'masters'))
 m_api.Backend = Mock()
 m_api.Command = Mock()
 m_api.Command.ping.return_value = {

--- a/tests/util.py
+++ b/tests/util.py
@@ -77,7 +77,7 @@ class KRAInstance:
 
 p_api = patch('ipalib.api', autospec=ipalib.api)
 m_api = p_api.start()
-m_api.isdone.return_value = False
+m_api.isdone.return_value = True
 m_api.env = Mock()
 m_api.env.host = 'server.ipa.example'
 m_api.env.server = 'server.ipa.example'


### PR DESCRIPTION
This checks a bunch of ADTrust options as outlined by Alexander.

The DS change is there because I set the wrong container originally and changing it to be right for AD Trust requires it be changed here as well. It's pedantic but could be important at some point.