### PR TITLE
Explicitly return SUCCESS instead of relying on core to do it

### DIFF
--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -728,6 +728,7 @@ class IPARAAgent(IPAPlugin):
             if not found:
                 yield Result(self, constants.ERROR,
                              msg='RA agent certificate not found in LDAP')
+            yield Result(self, constants.SUCCESS)
 
 
 @registry

--- a/tests/test_ipa_agent.py
+++ b/tests/test_ipa_agent.py
@@ -85,8 +85,12 @@ class TestNSSAgent(BaseTest):
         f.config = config.Config()
         self.results = capture_results(f)
 
-        # A valid call relies on a success to be set by core
-        assert len(self.results) == 0
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPARAAgent'
 
     def test_nss_agent_no_description(self):
 
@@ -213,4 +217,9 @@ class TestNSSAgent(BaseTest):
         f.config = config.Config()
         self.results = capture_results(f)
 
-        assert len(self.results) == 0
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPARAAgent'


### PR DESCRIPTION
This lets us be sure that a result is going to be returned in the
tests.