### PR TITLE
Add systemd timer to run healthcheck daily and write log file

### DIFF
--- a/systemd/README
+++ b/systemd/README
@@ -1,0 +1,27 @@
+To enable daily execution using a systemd timer:
+
+Create the log directory
+
+# mkdir /var/log/ipa/healthcheck
+
+Copy the systemd configuration into place
+
+# cp ipa-healthcheck.timer /usr/lib/systemd/system
+# cp ipa-healthcheck.service /usr/lib/systemd/system
+
+Tell systemd about it:
+
+#systemctl daemon-reload
+
+Enable it:
+
+# systemctl enable ipa-healthcheck.timer
+# systemctl start ipa-healthcheck.timer
+
+Put a shell script in place to do the invocation:
+
+# cp ipa-healthcheck.sh /usr/libexec/ipa
+
+To test:
+
+# systemctl start ipa-healthcheck

--- a/systemd/ipa-healthcheck.service
+++ b/systemd/ipa-healthcheck.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Execute IPA Healthcheck
+
+[Service]
+Type=simple
+ExecStart=/usr/libexec/ipa/ipa-healthcheck.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ipa-healthcheck.sh
+++ b/systemd/ipa-healthcheck.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+LOGDIR=/var/log/ipa/healthcheck
+DATE=$(date +%Y%m%d)
+
+/usr/bin/ipa-healthcheck --output-file $LOGDIR/healthcheck.log-$DATE

--- a/systemd/ipa-healthcheck.timer
+++ b/systemd/ipa-healthcheck.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Execute IPA Healthcheck every day at midnight
+
+[Timer]
+OnCalendar=*-*-* 00:00:00
+Unit=ipa-healthcheck.service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This will create a log file in /var/log/ipa/healthcheck at midnight.

The reason for the shell script is to have a configurable date.
systemd will not decode shell script variables and using bash -c
in the ExecStart line ipa-healthcheck was unable to communicate to
certmonger over DBus.