### PR TITLE
Make 'python3 setup.py test' work

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -57,4 +57,6 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     python_requires='!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
+    setup_requires=['pytest-runner',],
+    tests_require=['pytest',],
 )


### PR DESCRIPTION
Apply the steps for enabling testing using pytest provided at
https://docs.pytest.org/en/latest/goodpractices.html

This will make the check section in upstream packaging execute
the unit tests.