### PR TITLE
File system free space checks: add the backup directory

### DIFF
--- a/src/ipahealthcheck/system/filesystemspace.py
+++ b/src/ipahealthcheck/system/filesystemspace.py
@@ -17,6 +17,7 @@ class FileSystemSpaceCheck(SystemPlugin):
     # watch important directories for FreeIPA
     _pathchecks = {
         '/var/lib/dirsrv/': 1024,
+        '/var/lib/ipa/backup/': 512,
         '/var/log/': 1024,
         '/var/log/audit/': 512,
         '/var/tmp/': 512,

--- a/tests/test_system_filesystemspace.py
+++ b/tests/test_system_filesystemspace.py
@@ -42,8 +42,8 @@ class TestFileSystemNotEnoughFreeSpace(BaseTest):
                 assert 'free space under threshold' in result.kw.get('msg')
             else:
                 assert 'free space percentage within' in result.kw.get('msg')
-        assert len(self.results) == 10
-        assert count == 5
+        assert len(self.results) == 12
+        assert count == 6
 
 
 class TestFileSystemNotEnoughFreeSpacePercentage(BaseTest):
@@ -76,8 +76,8 @@ class TestFileSystemNotEnoughFreeSpacePercentage(BaseTest):
                 assert 'free space percentage under' in result.kw.get('msg')
             else:
                 assert 'free space within limits' in result.kw.get('msg')
-        assert len(self.results) == 10
-        assert count == 5
+        assert len(self.results) == 12
+        assert count == 6
 
 
 class TestFileSystemEnoughFreeSpace(BaseTest):
@@ -109,4 +109,4 @@ class TestFileSystemEnoughFreeSpace(BaseTest):
                 'free space percentage within' in result.kw.get('msg') or
                 'free space within limits' in result.kw.get('msg')
             )
-        assert len(self.results) == 10
+        assert len(self.results) == 12


### PR DESCRIPTION
Add /var/lib/ipa/backup to the directories we check for possible ENOSPC.