### PR TITLE
Report current and on-deck DNA range configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         # plugin modules for ipahealthcheck.ipa registry
         'ipahealthcheck.ipa': [
             'ipacerts = ipahealthcheck.ipa.certs',
+            'ipadna = ipahealthcheck.ipa.dna',
             'ipafiles = ipahealthcheck.ipa.files',
             'ipahost = ipahealthcheck.ipa.host',
             'ipatopology = ipahealthcheck.ipa.topology',

--- a/src/ipahealthcheck/ipa/dna.py
+++ b/src/ipahealthcheck/ipa/dna.py
@@ -1,0 +1,47 @@
+
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+import logging
+
+from ipahealthcheck.ipa.plugin import IPAPlugin, registry
+from ipahealthcheck.core.plugin import Result, duration
+from ipahealthcheck.core import constants
+
+from ipalib import api
+from ipaserver.install import replication
+
+
+logger = logging.getLogger()
+
+
+@registry
+class IPADNARangeCheck(IPAPlugin):
+    """
+    Report the configured DNA range, if any.
+
+    This expects some external system to analyze and determine if
+    any or all masters have a DNA range configured. It is not an error
+    if a master does not have a range. It IS an error if no masters have
+    a range.
+    """
+    @duration
+    def check(self):
+        agmt = replication.ReplicationManager(api.env.realm, api.env.host)
+
+        (range_start, range_max) = agmt.get_DNA_range(api.env.host)
+        (next_start, next_max) = agmt.get_DNA_next_range(api.env.host)
+
+        if range_start is not None:
+            yield Result(self, constants.SUCCESS,
+                         range_start=range_start,
+                         range_max=range_max,
+                         next_start=next_start or 0,
+                         next_max=next_max or 0)
+        else:
+            yield Result(self, constants.SUCCESS,
+                         range_start=0,
+                         range_max=0,
+                         next_start=0,
+                         next_max=0,
+                         msg='No range defined')

--- a/tests/test_ipa_dna.py
+++ b/tests/test_ipa_dna.py
@@ -1,0 +1,99 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+from base import BaseTest
+from unittest.mock import Mock, patch
+from util import capture_results
+
+from ipahealthcheck.core import config, constants
+from ipahealthcheck.ipa.plugin import registry
+from ipahealthcheck.ipa.dna import IPADNARangeCheck
+
+
+class mock_ReplicationManager:
+    def __init__(self, realm=None, host=None, start=None, max=None,
+                 next=None, next_max=None):
+        self.start = start
+        self.max = max
+        self.next = next
+        self.next_max = next_max
+
+    def get_DNA_range(self, host):
+        return self.start, self.max
+
+    def get_DNA_next_range(self, host):
+        return self.next, self.next_max
+
+
+class TestDNARange(BaseTest):
+    patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        Mock(return_value=None),
+    }
+
+    @patch('ipaserver.install.replication.ReplicationManager')
+    def test_dnarange_set(self, mock_manager):
+        mock_manager.return_value = mock_ReplicationManager(start=1, max=100)
+        framework = object()
+        registry.initialize(framework)
+        f = IPADNARangeCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.dna'
+        assert result.check == 'IPADNARangeCheck'
+        assert result.kw.get('range_start') == 1
+        assert result.kw.get('range_max') == 100
+        assert result.kw.get('next_start') == 0
+        assert result.kw.get('next_max') == 0
+
+    @patch('ipaserver.install.replication.ReplicationManager')
+    def test_dnarange_noset(self, mock_manager):
+        mock_manager.return_value = mock_ReplicationManager()
+        framework = object()
+        registry.initialize(framework)
+        f = IPADNARangeCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.dna'
+        assert result.check == 'IPADNARangeCheck'
+        assert result.kw.get('range_start') == 0
+        assert result.kw.get('range_max') == 0
+        assert result.kw.get('next_start') == 0
+        assert result.kw.get('next_max') == 0
+
+    @patch('ipaserver.install.replication.ReplicationManager')
+    def test_dnarange_next(self, mock_manager):
+        mock_manager.return_value = mock_ReplicationManager(start=1,
+                                                            max=100,
+                                                            next=101,
+                                                            next_max=200)
+        framework = object()
+        registry.initialize(framework)
+        f = IPADNARangeCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.dna'
+        assert result.check == 'IPADNARangeCheck'
+        assert result.kw.get('range_start') == 1
+        assert result.kw.get('range_max') == 100
+        assert result.kw.get('next_start') == 101
+        assert result.kw.get('next_max') == 200


### PR DESCRIPTION
This will need to be aggregated elsewhere. It always reports as
success unless collecting the data fails.