### PR TITLE
Report status if master is the CRL generator or renewal master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
             'ipacerts = ipahealthcheck.ipa.certs',
             'ipafiles = ipahealthcheck.ipa.files',
             'ipahost = ipahealthcheck.ipa.host',
+            'iparoles = ipahealthcheck.ipa.roles',
             'ipatopology = ipahealthcheck.ipa.topology',
             'ipatrust = ipahealthcheck.ipa.trust',
         ],

--- a/src/ipahealthcheck/ipa/roles.py
+++ b/src/ipahealthcheck/ipa/roles.py
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+import logging
+
+from ipahealthcheck.ipa.plugin import IPAPlugin, registry
+from ipahealthcheck.core.plugin import Result
+from ipahealthcheck.core.plugin import duration
+from ipahealthcheck.core import constants
+
+from ipalib import api
+
+logger = logging.getLogger()
+
+
+@registry
+class IPACRLManagerCheck(IPAPlugin):
+    """
+    Determine if this master is the CRL manager
+
+    This check in itself will always return SUCCESS and is only
+    useful in the context of the ohter masters. Some external
+    service is expected to aggregate this.
+    """
+    @duration
+    def check(self):
+        try:
+            enabled = self.ca.is_crlgen_enabled()
+        except AttributeError:
+            yield Result(self, constants.SUCCESS,
+                         key='crl_manager',
+                         crlgen_enabled=None,
+                         msg='Not available in this version of IPA')
+        else:
+            yield Result(self, constants.SUCCESS,
+                         key='crl_manager',
+                         crlgen_enabled=enabled)
+
+
+@registry
+class IPARenewalMasterCheck(IPAPlugin):
+    """
+    Determine if this master is the CA renewal master.
+
+    This check in itself will always return SUCCESS and is only
+    useful in the context of the ohter masters. Some external
+    service is expected to aggregate this.
+    """
+    @duration
+    def check(self):
+        try:
+            result = api.Command.config_show()
+        except Exception as e:
+            yield Result(self, constants.ERROR,
+                         key='renewal_master',
+                         msg='Request for configuration failed, %s' % e)
+        else:
+            server = result['result'].get('ca_renewal_master_server', None)
+            yield Result(self, constants.SUCCESS,
+                         key='renewal_master',
+                         master=server == api.env.host)

--- a/tests/test_ipa_roles.py
+++ b/tests/test_ipa_roles.py
@@ -1,0 +1,128 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+from base import BaseTest
+from unittest.mock import Mock, patch
+from util import capture_results, CAInstance
+from util import m_api
+
+from ipahealthcheck.core import config, constants
+from ipahealthcheck.ipa.plugin import registry
+from ipahealthcheck.ipa.roles import (IPACRLManagerCheck,
+                                      IPARenewalMasterCheck)
+
+
+class TestCRLManagerRole(BaseTest):
+    patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        Mock(return_value=None),
+    }
+
+    @patch('ipaserver.install.cainstance.CAInstance')
+    def test_not_crlmanager(self, mock_ca):
+        mock_ca.return_value = CAInstance(crlgen=False)
+        framework = object()
+        registry.initialize(framework)
+        f = IPACRLManagerCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.roles'
+        assert result.check == 'IPACRLManagerCheck'
+        assert result.kw.get('crlgen_enabled') is False
+
+    @patch('ipaserver.install.cainstance.CAInstance')
+    def test_crlmanager(self, mock_ca):
+        mock_ca.return_value = CAInstance()
+        framework = object()
+        registry.initialize(framework)
+        f = IPACRLManagerCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.roles'
+        assert result.check == 'IPACRLManagerCheck'
+        assert result.kw.get('crlgen_enabled') is True
+
+
+class TestRenewalMaster(BaseTest):
+    patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        Mock(return_value=None),
+    }
+
+    def test_renewal_master_not_set(self):
+        framework = object()
+        registry.initialize(framework)
+        f = IPARenewalMasterCheck(registry)
+
+        m_api.Command.config_show.side_effect = [{
+            'result': {
+            }
+        }]
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.roles'
+        assert result.check == 'IPARenewalMasterCheck'
+        assert result.kw.get('master') is False
+
+    def test_not_renewal_master(self):
+        framework = object()
+        registry.initialize(framework)
+        f = IPARenewalMasterCheck(registry)
+
+        m_api.Command.config_show.side_effect = [{
+            'result': {
+                'ca_renewal_master_server': 'something.ipa.example'
+            }
+        }]
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.roles'
+        assert result.check == 'IPARenewalMasterCheck'
+        assert result.kw.get('master') is False
+
+    def test_is_renewal_master(self):
+        framework = object()
+        registry.initialize(framework)
+        f = IPARenewalMasterCheck(registry)
+
+        m_api.Command.config_show.side_effect = [{
+            'result': {
+                'ca_renewal_master_server': 'server.ipa.example'
+            }
+        }]
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.severity == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.roles'
+        assert result.check == 'IPARenewalMasterCheck'
+        assert result.kw.get('master') is True

--- a/tests/util.py
+++ b/tests/util.py
@@ -52,11 +52,15 @@ class CAInstance:
        This is needed to control whether the underlying master is
        CAless or CAful.
     """
-    def __init__(self, enabled=True):
+    def __init__(self, enabled=True, crlgen=True):
         self.enabled = enabled
+        self.crlgen = crlgen
 
     def is_configured(self):
         return self.enabled
+
+    def is_crlgen_enabled(self):
+        return self.crlgen
 
 
 class KRAInstance:


### PR DESCRIPTION
This will need to be aggregated elsewhere. It always reports as
success unless collecting the data fails.