### PR TITLE
Display text based severity instead of numeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,14 @@ A basic check module consists of:
 
 A check yields a Result. This contains the outcome of the check including:
 
-* severity as defined in ipahealthcheck/core/constants.py
+* result as defined in ipahealthcheck/core/constants.py
 * msg containing a message to be displayed to the user.
 * kw, a python dictionary of name value pairs that provide details on the error
 
 The kw dict is meant to provide context for the check. Err on the side of
 too much information.
 
-msg and kw are optional if severity is SUCCESS.
+msg and kw are optional if result is SUCCESS.
 
 If a check consist of only a single test then it is not required to yield
 a Result, one marking the check as successful will be added automatically.

--- a/man/man1/ipa-healthcheck.1
+++ b/man/man1/ipa-healthcheck.1
@@ -15,7 +15,7 @@ These areas of the system to check can be logically grouped together. This group
 
 A check is as atomic as possible to limit the scope and complexity and provide a yes/no answer on whether that particular configuration is correct.
 
-Each check will return a result, either a severity of WARNING, ERROR or CRITICAL or SUCCESS. Returning SUCCESS tells you that the check was done and was deemed correct. This should help track when the last time something was examined.
+Each check will return a result, either a result of WARNING, ERROR or CRITICAL or SUCCESS. Returning SUCCESS tells you that the check was done and was deemed correct. This should help track when the last time something was examined.
 
 Upon failure the output will include the source and check that detected the failure along with a message and name/value pairs indicating the problem. It may very well be that the check can't make a final determination and generally defaults to WARNING if it can't be sure so that it can be examined.
 

--- a/src/ipahealthcheck/core/constants.py
+++ b/src/ipahealthcheck/core/constants.py
@@ -4,7 +4,7 @@
 
 DEFAULT_OUTPUT = 'json'
 
-# Error reporting severity
+# Error reporting result
 SUCCESS = 0
 CRITICAL = 1
 ERROR = 2

--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -80,7 +80,7 @@ def run_service_plugins(plugins, config, source, check):
 
         logger.debug('Calling check %s', plugin)
         for result in plugin.check():
-            if result is not None and result.severity == constants.SUCCESS:
+            if result is not None and result.result == constants.SUCCESS:
                 available.append(plugin.service.service_name)
             if result is not None:
                 results.add(result)
@@ -148,7 +148,7 @@ def parse_options(output_registry):
                         default='json', help='Output method')
     parser.add_argument('--failures-only', dest='failures_only',
                         action='store_true', default=False,
-                        help='Exclude SUCCESS severity on output')
+                        help='Exclude SUCCESS result on output')
     for plugin in output_registry.plugins:
         onelinedoc = plugin.__doc__.split('\n\n', 1)[0].strip()
         group = parser.add_argument_group(plugin.__name__.lower(),
@@ -222,7 +222,7 @@ def main():
 
     return_value = 0
     for result in results.results:
-        if result.severity != constants.SUCCESS:
+        if result.result != constants.SUCCESS:
             return_value = 1
             break
 

--- a/src/ipahealthcheck/core/output.py
+++ b/src/ipahealthcheck/core/output.py
@@ -59,8 +59,8 @@ class JSON(Output):
 
         output = []
         for line in data.output():
-            severity = line.get('severity')
-            if self.failures_only and int(severity) == SUCCESS:
+            result = line.get('result')
+            if self.failures_only and int(result) == SUCCESS:
                 continue
             output.append(line)
         f.write(json.dumps(output, indent=self.indent))
@@ -101,12 +101,12 @@ class Human(Output):
 
         for line in data.output():
             kw = line.get('kw')
-            severity = line.get('severity')
+            result = line.get('result')
             source = line.get('source')
             check = line.get('check')
-            if self.failures_only and int(severity) == SUCCESS:
+            if self.failures_only and int(result) == SUCCESS:
                 continue
-            print('%s: %s.%s' % (getLevelName(severity), source, check),
+            print('%s: %s.%s' % (getLevelName(result), source, check),
                   end='')
             if 'key' in kw:
                 print('.%s' % kw.get('key'), end='')

--- a/src/ipahealthcheck/core/plugin.py
+++ b/src/ipahealthcheck/core/plugin.py
@@ -105,7 +105,7 @@ class Result:
     The result of a check.
 
     :param plugin: The plugin which generated the result.
-    :param severity: A severity constant representing the level of error.
+    :param result: A result constant representing the level of error.
     :param source: If no plugin is passed then the name of the source
                    can be provided directly.
     :param check: If no plugin is passed then the name of the check
@@ -123,9 +123,9 @@ class Result:
         msg: A message that can take other keywords as input
         exception: used when a check raises an exception
     """
-    def __init__(self, plugin, severity, source=None, check=None,
+    def __init__(self, plugin, result, source=None, check=None,
                  start=None, **kw):
-        self.severity = severity
+        self.result = result
         self.kw = kw
         self.when = generalized_time(datetime.utcnow())
         self.duration = None
@@ -142,11 +142,11 @@ class Result:
             dur = datetime.utcnow() - start
             self.duration = '%6.6f' % dur.total_seconds()
 
-        assert getLevelName(severity) is not None
+        assert getLevelName(result) is not None
 
     def __repr__(self):
         return "%s.%s(%s): %s" % (self.source, self.check, self.kw,
-                                  self.severity)
+                                  self.result)
 
 
 class Results:
@@ -181,7 +181,7 @@ class Results:
         for result in self.results:
             yield dict(source=result.source,
                        check=result.check,
-                       severity=result.severity,
+                       result=getLevelName(result.result),
                        uuid=result.uuid,
                        when=result.when,
                        duration=result.duration,
@@ -199,11 +199,11 @@ def json_to_results(data):
     results = Results()
 
     for line in data:
-        severity = line.pop('severity')
+        result = line.pop('result')
         source = line.pop('source')
         check = line.pop('check')
         kw = line.pop('kw')
-        result = Result(None, severity, source, check, **kw)
+        result = Result(None, result, source, check, **kw)
         results.add(result)
 
     return results

--- a/tests/base.py
+++ b/tests/base.py
@@ -35,7 +35,7 @@ class BaseTest(TestCase):
     def tearDown(self):
         """
         Ensure that no exceptions snuck into the results which might not
-        be noticed because an exception may have the same severity as
+        be noticed because an exception may have the same result as
         the expected result.
         """
         no_exceptions(self.results)

--- a/tests/test_core_files.py
+++ b/tests/test_core_files.py
@@ -51,14 +51,14 @@ def test_files_owner(mock_stat):
     results = capture_results(f)
 
     my_results = get_results(results, 'owner')
-    assert my_results.results[0].severity == constants.SUCCESS
-    assert my_results.results[1].severity == constants.WARNING
+    assert my_results.results[0].result == constants.SUCCESS
+    assert my_results.results[1].result == constants.WARNING
 
     mock_stat.return_value = make_stat(uid=nobody.pw_uid)
     results = capture_results(f)
     my_results = get_results(results, 'owner')
-    assert my_results.results[0].severity == constants.WARNING
-    assert my_results.results[1].severity == constants.SUCCESS
+    assert my_results.results[0].result == constants.WARNING
+    assert my_results.results[1].result == constants.SUCCESS
 
 
 @patch('os.stat')
@@ -71,14 +71,14 @@ def test_files_group(mock_stat):
     results = capture_results(f)
 
     my_results = get_results(results, 'group')
-    assert my_results.results[0].severity == constants.SUCCESS
-    assert my_results.results[1].severity == constants.WARNING
+    assert my_results.results[0].result == constants.SUCCESS
+    assert my_results.results[1].result == constants.WARNING
 
     mock_stat.return_value = make_stat(gid=nobody.pw_gid)
     results = capture_results(f)
     my_results = get_results(results, 'group')
-    assert my_results.results[0].severity == constants.WARNING
-    assert my_results.results[1].severity == constants.SUCCESS
+    assert my_results.results[0].result == constants.WARNING
+    assert my_results.results[1].result == constants.SUCCESS
 
 
 @patch('os.stat')
@@ -91,11 +91,11 @@ def test_files_mode(mock_stat):
     results = capture_results(f)
 
     my_results = get_results(results, 'mode')
-    assert my_results.results[0].severity == constants.SUCCESS
-    assert my_results.results[1].severity == constants.WARNING
+    assert my_results.results[0].result == constants.SUCCESS
+    assert my_results.results[1].result == constants.WARNING
 
     mock_stat.return_value = make_stat(mode=33204)
     results = capture_results(f)
     my_results = get_results(results, 'mode')
-    assert my_results.results[0].severity == constants.WARNING
-    assert my_results.results[1].severity == constants.SUCCESS
+    assert my_results.results[0].result == constants.WARNING
+    assert my_results.results[1].result == constants.SUCCESS

--- a/tests/test_dogtag_ca.py
+++ b/tests/test_dogtag_ca.py
@@ -70,7 +70,7 @@ class TestCACerts(BaseTest):
         assert len(self.results) == 6
 
         for result in self.results.results:
-            assert result.severity == constants.SUCCESS
+            assert result.result == constants.SUCCESS
             assert result.source == 'ipahealthcheck.dogtag.ca'
             assert result.check == 'DogtagCertsConfigCheck'
 
@@ -111,13 +111,13 @@ class TestCACerts(BaseTest):
             if r == 2:  # skip the one that should be bad
                 continue
             result = self.results.results[r]
-            assert result.severity == constants.SUCCESS
+            assert result.result == constants.SUCCESS
             assert result.source == 'ipahealthcheck.dogtag.ca'
             assert result.check == 'DogtagCertsConfigCheck'
 
         result = self.results.results[2]
 
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.dogtag.ca'
         assert result.check == 'DogtagCertsConfigCheck'
         assert result.kw.get('key') == 'auditSigningCert cert-pki-ca'

--- a/tests/test_dogtag_connectivity.py
+++ b/tests/test_dogtag_connectivity.py
@@ -36,7 +36,7 @@ class TestCAConnectivity(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.dogtag.ca'
         assert result.check == 'DogtagCertsConnectivityCheck'
 
@@ -57,7 +57,7 @@ class TestCAConnectivity(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.dogtag.ca'
         assert result.check == 'DogtagCertsConnectivityCheck'
 
@@ -77,7 +77,7 @@ class TestCAConnectivity(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.dogtag.ca'
         assert result.check == 'DogtagCertsConnectivityCheck'
         assert 'Unable to communicate' in result.kw.get('msg')

--- a/tests/test_ds_replication.py
+++ b/tests/test_ds_replication.py
@@ -59,7 +59,7 @@ class TestReplicationConflicts(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ds.replication'
         assert result.check == 'ReplicationConflictCheck'
 
@@ -85,7 +85,7 @@ class TestReplicationConflicts(BaseTest):
         self.results = capture_results(f)
         result = self.results.results[0]
 
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ds.replication'
         assert result.check == 'ReplicationConflictCheck'
         assert result.kw.get('msg') == 'Replication conflict'

--- a/tests/test_ipa_agent.py
+++ b/tests/test_ipa_agent.py
@@ -88,7 +88,7 @@ class TestNSSAgent(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPARAAgent'
 
@@ -111,7 +111,7 @@ class TestNSSAgent(BaseTest):
         self.results = capture_results(f)
         result = self.results.results[0]
 
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.kw.get('msg') == 'RA agent is missing description'
 
     @patch('ipalib.x509.load_certificate_from_file')
@@ -127,7 +127,7 @@ class TestNSSAgent(BaseTest):
         self.results = capture_results(f)
         result = self.results.results[0]
 
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.kw.get('msg') == 'Unable to load RA cert: test'
 
     def test_nss_agent_no_entry_found(self):
@@ -141,7 +141,7 @@ class TestNSSAgent(BaseTest):
         self.results = capture_results(f)
         result = self.results.results[0]
 
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.kw.get('msg') == 'RA agent not found in LDAP'
 
     def test_nss_agent_too_many(self):
@@ -168,7 +168,7 @@ class TestNSSAgent(BaseTest):
         self.results = capture_results(f)
         result = self.results.results[0]
 
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.kw.get('msg') == 'Too many RA agent entries found, 2'
 
     def test_nss_agent_nonmatching_cert(self):
@@ -193,7 +193,7 @@ class TestNSSAgent(BaseTest):
         self.results = capture_results(f)
         result = self.results.results[0]
 
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.kw.get('msg') == 'RA agent certificate not found in LDAP'
 
     def test_nss_agent_multiple_certs(self):
@@ -220,6 +220,6 @@ class TestNSSAgent(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPARAAgent'

--- a/tests/test_ipa_certfile_expiration.py
+++ b/tests/test_ipa_certfile_expiration.py
@@ -53,7 +53,7 @@ class TestIPACertificateFile(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertfileExpirationCheck'
         assert result.kw.get('key') == '1234'
@@ -77,7 +77,7 @@ class TestIPACertificateFile(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.WARNING
+        assert result.result == constants.WARNING
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertfileExpirationCheck'
         assert result.kw.get('key') == '1234'
@@ -102,7 +102,7 @@ class TestIPACertificateFile(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertfileExpirationCheck'
         assert result.kw.get('key') == '1234'

--- a/tests/test_ipa_certmonger_ca.py
+++ b/tests/test_ipa_certmonger_ca.py
@@ -34,7 +34,7 @@ class TestCertmonger(BaseTest):
         assert len(self.results) == 3
 
         for result in self.results.results:
-            assert result.severity == constants.SUCCESS
+            assert result.result == constants.SUCCESS
             assert result.source == 'ipahealthcheck.ipa.certs'
             assert result.check == 'IPACertmongerCA'
 
@@ -55,11 +55,11 @@ class TestCertmonger(BaseTest):
 
         for r in range(0, 1):
             result = self.results.results[r]
-            assert result.severity == constants.SUCCESS
+            assert result.result == constants.SUCCESS
             assert result.source == 'ipahealthcheck.ipa.certs'
             assert result.check == 'IPACertmongerCA'
 
-        assert self.results.results[2].severity == constants.ERROR
+        assert self.results.results[2].result == constants.ERROR
         assert self.results.results[2].kw.get('key') == \
             'dogtag-ipa-ca-renew-agent-reuse'
         assert self.results.results[2].kw.get('msg') == \

--- a/tests/test_ipa_dna.py
+++ b/tests/test_ipa_dna.py
@@ -45,7 +45,7 @@ class TestDNARange(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.dna'
         assert result.check == 'IPADNARangeCheck'
         assert result.kw.get('range_start') == 1
@@ -66,7 +66,7 @@ class TestDNARange(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.dna'
         assert result.check == 'IPADNARangeCheck'
         assert result.kw.get('range_start') == 0
@@ -90,7 +90,7 @@ class TestDNARange(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.dna'
         assert result.check == 'IPADNARangeCheck'
         assert result.kw.get('range_start') == 1

--- a/tests/test_ipa_expiration.py
+++ b/tests/test_ipa_expiration.py
@@ -41,7 +41,7 @@ class TestExpiration(BaseTest):
         assert len(self.results) == 2
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertmongerExpirationCheck'
         assert result.kw.get('key') == '1234'
@@ -49,7 +49,7 @@ class TestExpiration(BaseTest):
                                        '19700101001704Z'
 
         result = self.results.results[1]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertmongerExpirationCheck'
         assert result.kw.get('key') == '5678'
@@ -77,13 +77,13 @@ class TestExpiration(BaseTest):
         assert len(self.results) == 2
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertmongerExpirationCheck'
         assert result.kw.get('key') == '5678'
 
         result = self.results.results[1]
-        assert result.severity == constants.WARNING
+        assert result.result == constants.WARNING
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertmongerExpirationCheck'
         assert result.kw.get('key') == '7777'

--- a/tests/test_ipa_nssdb.py
+++ b/tests/test_ipa_nssdb.py
@@ -57,7 +57,7 @@ class TestNSSDBTrust(BaseTest):
         assert len(self.results) == 4
 
         for result in self.results.results:
-            assert result.severity == constants.SUCCESS
+            assert result.result == constants.SUCCESS
             assert result.source == 'ipahealthcheck.ipa.certs'
             assert result.check == 'IPACertNSSTrust'
             assert 'cert-pki-ca' in result.kw.get('key')
@@ -85,14 +85,14 @@ class TestNSSDBTrust(BaseTest):
         num = len(self.results.results) - 2
         for r in range(0, num):
             result = self.results.results[r]
-            assert result.severity == constants.SUCCESS
+            assert result.result == constants.SUCCESS
             assert result.source == 'ipahealthcheck.ipa.certs'
             assert result.check == 'IPACertNSSTrust'
             assert 'cert-pki-ca' in result.kw.get('key')
 
         result = self.results.results[-1]
 
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertNSSTrust'
         assert result.kw.get('key') == 'ocspSigningCert cert-pki-ca'
@@ -122,7 +122,7 @@ class TestNSSDBTrust(BaseTest):
 
         result = self.results.results[1]
 
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertNSSTrust'
         assert result.kw.get('key') == 'subsystemCert cert-pki-ca'
@@ -132,7 +132,7 @@ class TestNSSDBTrust(BaseTest):
 
         result = self.results.results[3]
 
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertNSSTrust'
         assert result.kw.get('key') == 'Server-Cert cert-pki-ca'

--- a/tests/test_ipa_nssvalidation.py
+++ b/tests/test_ipa_nssvalidation.py
@@ -49,7 +49,7 @@ class TestNSSValidation(BaseTest):
         assert len(self.results) == 2
 
         for result in self.results.results:
-            assert result.severity == constants.SUCCESS
+            assert result.result == constants.SUCCESS
             assert result.source == 'ipahealthcheck.ipa.certs'
             assert result.check == 'IPANSSChainValidation'
 
@@ -79,7 +79,7 @@ class TestNSSValidation(BaseTest):
         assert len(self.results) == 2
 
         for result in self.results.results:
-            assert result.severity == constants.ERROR
+            assert result.result == constants.ERROR
             assert result.source == 'ipahealthcheck.ipa.certs'
             assert result.check == 'IPANSSChainValidation'
 
@@ -108,7 +108,7 @@ class TestNSSValidation(BaseTest):
         assert len(self.results) == 1
 
         for result in self.results.results:
-            assert result.severity == constants.SUCCESS
+            assert result.result == constants.SUCCESS
             assert result.source == 'ipahealthcheck.ipa.certs'
             assert result.check == 'IPANSSChainValidation'
             assert 'slapd-' in result.kw.get('key')

--- a/tests/test_ipa_opensslvalidation.py
+++ b/tests/test_ipa_opensslvalidation.py
@@ -41,7 +41,7 @@ class TestOpenSSLValidation(BaseTest):
         assert len(self.results) == 2
 
         for result in self.results.results:
-            assert result.severity == constants.SUCCESS
+            assert result.result == constants.SUCCESS
             assert result.source == 'ipahealthcheck.ipa.certs'
             assert result.check == 'IPAOpenSSLChainValidation'
 
@@ -70,7 +70,7 @@ class TestOpenSSLValidation(BaseTest):
         assert len(self.results) == 2
 
         for result in self.results.results:
-            assert result.severity == constants.ERROR
+            assert result.result == constants.ERROR
             assert result.source == 'ipahealthcheck.ipa.certs'
             assert result.check == 'IPAOpenSSLChainValidation'
             assert 'failed' in result.kw.get('msg')

--- a/tests/test_ipa_revocation.py
+++ b/tests/test_ipa_revocation.py
@@ -65,7 +65,7 @@ class TestRevocation(BaseTest):
         assert len(self.results) == 2
 
         for result in self.results.results:
-            assert result.severity == constants.SUCCESS
+            assert result.result == constants.SUCCESS
             assert result.source == 'ipahealthcheck.ipa.certs'
             assert result.check == 'IPACertRevocation'
 
@@ -95,12 +95,12 @@ class TestRevocation(BaseTest):
         assert len(self.results) == 2
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertRevocation'
 
         result = self.results.results[1]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertRevocation'
         assert result.kw.get('revocation_reason') == 'superseded'

--- a/tests/test_ipa_roles.py
+++ b/tests/test_ipa_roles.py
@@ -32,7 +32,7 @@ class TestCRLManagerRole(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.roles'
         assert result.check == 'IPACRLManagerCheck'
         assert result.kw.get('crlgen_enabled') is False
@@ -50,7 +50,7 @@ class TestCRLManagerRole(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.roles'
         assert result.check == 'IPACRLManagerCheck'
         assert result.kw.get('crlgen_enabled') is True
@@ -78,7 +78,7 @@ class TestRenewalMaster(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.roles'
         assert result.check == 'IPARenewalMasterCheck'
         assert result.kw.get('master') is False
@@ -100,7 +100,7 @@ class TestRenewalMaster(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.roles'
         assert result.check == 'IPARenewalMasterCheck'
         assert result.kw.get('master') is False
@@ -122,7 +122,7 @@ class TestRenewalMaster(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.roles'
         assert result.check == 'IPARenewalMasterCheck'
         assert result.kw.get('master') is True

--- a/tests/test_ipa_topology.py
+++ b/tests/test_ipa_topology.py
@@ -43,7 +43,7 @@ class TestTopology(BaseTest):
         assert len(self.results) == 2
 
         for result in self.results.results:
-            assert result.severity == constants.SUCCESS
+            assert result.result == constants.SUCCESS
             assert result.source == 'ipahealthcheck.ipa.topology'
             assert result.check == 'IPATopologyDomainCheck'
 
@@ -92,7 +92,7 @@ class TestTopology(BaseTest):
         # The first two results are failures in the domain suffix, the
         # third is a success in the ca suffix.
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.kw.get('key') == 'ipa.example.test'
         assert result.kw.get('replicas') == ['replica2.example.test']
         assert result.kw.get('suffix') == 'domain'
@@ -100,7 +100,7 @@ class TestTopology(BaseTest):
         assert 'can\'t contact servers' in result.kw.get('msg')
 
         result = self.results.results[1]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.kw.get('key') == 'replica2.example.test'
         assert result.kw.get('replicas') == ['ipa.example.test']
         assert result.kw.get('suffix') == 'domain'
@@ -108,7 +108,7 @@ class TestTopology(BaseTest):
         assert 'can\'t contact servers' in result.kw.get('msg')
 
         result = self.results.results[2]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.kw.get('suffix') == 'ca'
 
     def test_topology_ca_bad(self):
@@ -156,11 +156,11 @@ class TestTopology(BaseTest):
         # The first result is ok (domain) and the last two are failures
         # (ca)
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.kw.get('suffix') == 'domain'
 
         result = self.results.results[1]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.kw.get('key') == 'ipa.example.test'
         assert result.kw.get('replicas') == ['replica2.example.test']
         assert result.kw.get('suffix') == 'ca'
@@ -168,7 +168,7 @@ class TestTopology(BaseTest):
         assert 'can\'t contact servers' in result.kw.get('msg')
 
         result = self.results.results[2]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.kw.get('key') == 'replica2.example.test'
         assert result.kw.get('replicas') == ['ipa.example.test']
         assert result.kw.get('suffix') == 'ca'
@@ -212,7 +212,7 @@ class TestTopology(BaseTest):
             assert result.check == 'IPATopologyDomainCheck'
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.kw.get('key') == 'ipa.example.test'
         assert result.kw.get('replicas') == ['replica2.example.test']
         assert result.kw.get('suffix') == 'domain'
@@ -220,5 +220,5 @@ class TestTopology(BaseTest):
         assert 'recommended max' in result.kw.get('msg')
 
         result = self.results.results[1]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.kw.get('suffix') == 'ca'

--- a/tests/test_ipa_tracking.py
+++ b/tests/test_ipa_tracking.py
@@ -49,7 +49,7 @@ class TestTracking(BaseTest):
         assert len(self.results) == 2
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertTracking'
         assert result.kw.get('msg') == "Missing tracking for {" \
@@ -81,7 +81,7 @@ class TestTracking(BaseTest):
         assert len(self.results) == 3
 
         result = self.results.results[2]
-        assert result.severity == constants.WARNING
+        assert result.result == constants.WARNING
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertTracking'
         assert result.kw.get('msg') == 'Unknown certmonger id 7777'

--- a/tests/test_ipa_trust.py
+++ b/tests/test_ipa_trust.py
@@ -134,7 +134,7 @@ class TestTrustAgent(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustAgentCheck'
 
@@ -153,7 +153,7 @@ class TestTrustAgent(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustAgentCheck'
         assert result.kw.get('key') == 'ipa_server_mode_false'
@@ -174,7 +174,7 @@ class TestTrustAgent(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustAgentCheck'
         assert result.kw.get('key') == 'ipa_server_mode_missing'
@@ -217,7 +217,7 @@ class TestTrustDomains(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustDomainsCheck'
         assert result.kw.get('key') == 'domain_list_error'
@@ -245,7 +245,7 @@ class TestTrustDomains(BaseTest):
         # There are more than one result I just care about this particular
         # value. The error is not fatal.
         result = self.results.results[0]
-        assert result.severity == constants.WARNING
+        assert result.result == constants.WARNING
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustDomainsCheck'
         assert result.kw.get('key') == 'trust-find'
@@ -292,7 +292,7 @@ class TestTrustDomains(BaseTest):
         assert len(self.results) == 3
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustDomainsCheck'
         assert result.kw.get('key') == 'domain-list'
@@ -300,14 +300,14 @@ class TestTrustDomains(BaseTest):
         assert result.kw.get('sssd_domains') == 'ad.example, child.example'
 
         result = self.results.results[1]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustDomainsCheck'
         assert result.kw.get('key') == 'domain-status'
         assert result.kw.get('domain') == 'ad.example'
 
         result = self.results.results[2]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustDomainsCheck'
         assert result.kw.get('key') == 'domain-status'
@@ -355,7 +355,7 @@ class TestTrustDomains(BaseTest):
         assert len(self.results) == 2
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustDomainsCheck'
         assert result.kw.get('key') == 'domain-list'
@@ -363,7 +363,7 @@ class TestTrustDomains(BaseTest):
         assert result.kw.get('sssd_domains') == 'child.example'
 
         result = self.results.results[1]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustDomainsCheck'
         assert result.kw.get('key') == 'domain-status'
@@ -451,25 +451,25 @@ class TestTrustCatalog(BaseTest):
         assert len(self.results) == 4
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustCatalogCheck'
         assert result.kw.get('key') == 'AD Global Catalog'
 
         result = self.results.results[1]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustCatalogCheck'
         assert result.kw.get('key') == 'AD Domain Controller'
 
         result = self.results.results[2]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustCatalogCheck'
         assert result.kw.get('key') == 'AD Global Catalog'
 
         result = self.results.results[1]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustCatalogCheck'
         assert result.kw.get('key') == 'AD Domain Controller'
@@ -516,13 +516,13 @@ class Testsidgen(BaseTest):
         assert len(self.results) == 2
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPAsidgenpluginCheck'
         assert result.kw.get('key') == 'IPA SIDGEN'
 
         result = self.results.results[1]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPAsidgenpluginCheck'
         assert result.kw.get('key') == 'ipa-sidgen-task'
@@ -548,13 +548,13 @@ class Testsidgen(BaseTest):
         assert len(self.results) == 2
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPAsidgenpluginCheck'
         assert result.kw.get('key') == 'IPA SIDGEN'
 
         result = self.results.results[1]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPAsidgenpluginCheck'
         assert result.kw.get('key') == 'ipa-sidgen-task'
@@ -606,7 +606,7 @@ class TestTrustAgentMember(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustAgentMemberCheck'
         assert result.kw.get('key') == m_api.env.host
@@ -634,7 +634,7 @@ class TestTrustAgentMember(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustAgentMemberCheck'
         assert result.kw.get('key') == m_api.env.host
@@ -687,7 +687,7 @@ class TestControllerPrincipal(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustControllerPrincipalCheck'
         assert result.kw.get('key') == 'cifs/%s@%s' % \
@@ -716,7 +716,7 @@ class TestControllerPrincipal(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.kw.get('key') == 'cifs/%s@%s' % \
                                        (m_api.env.host, m_api.env.realm)
@@ -764,7 +764,7 @@ class TestControllerService(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustControllerServiceCheck'
         assert result.kw.get('key') == 'ADTRUST'
@@ -791,7 +791,7 @@ class TestControllerService(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.kw.get('key') == 'ADTRUST'
 
@@ -839,7 +839,7 @@ class TestControllerGroupSID(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustControllerGroupSIDCheck'
         assert result.kw.get('key') == 'ipantsecurityidentifier'
@@ -868,7 +868,7 @@ class TestControllerGroupSID(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.ERROR
+        assert result.result == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustControllerGroupSIDCheck'
         assert result.kw.get('key') == 'ipantsecurityidentifier'
@@ -915,7 +915,7 @@ class TestControllerConf(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustControllerConfCheck'
         assert result.kw.get('key') == 'net conf list'
@@ -938,7 +938,7 @@ class TestPackageCheck(BaseTest):
         self.results = capture_results(f)
         assert len(self.results) == 1
         result = self.results.results[0]
-        assert result.severity == constants.SUCCESS
+        assert result.result == constants.SUCCESS
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustPackageCheck'
 
@@ -956,7 +956,7 @@ class TestPackageCheck(BaseTest):
         self.results = capture_results(f)
         assert len(self.results) == 1
         result = self.results.results[0]
-        assert result.severity == constants.WARNING
+        assert result.result == constants.WARNING
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustPackageCheck'
         sys.modules['ipaserver.install'] = save

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -23,7 +23,7 @@ def test_Result():
 
     e = raises(TypeError, Result)
     assert str(e) == "__init__() missing 2 required positional arguments: " \
-                     "'plugin' and 'severity'"
+                     "'plugin' and 'result'"
 
     # Test passing source and check to Result. This is used for loading
     # a previous output.
@@ -66,5 +66,6 @@ def test_Result():
     for x in output:
         assert x['source'] == 'ipahealthcheck.core.plugin'
         assert x['check'] == 'Plugin'
-        assert x['severity'] in (constants.SUCCESS, constants.CRITICAL)
+        assert x['result'] in (constants.getLevelName(constants.SUCCESS),
+                               constants.getLevelName(constants.CRITICAL))
         assert len(x['kw']) == 0

--- a/tests/test_system_filesystemspace.py
+++ b/tests/test_system_filesystemspace.py
@@ -35,7 +35,7 @@ class TestFileSystemNotEnoughFreeSpace(BaseTest):
 
         count = 0
         for result in self.results.results:
-            if result.severity == constants.ERROR:
+            if result.result == constants.ERROR:
                 count += 1
                 assert result.source == 'ipahealthcheck.system.filesystemspace'
                 assert result.check == 'FileSystemSpaceCheck'
@@ -69,7 +69,7 @@ class TestFileSystemNotEnoughFreeSpacePercentage(BaseTest):
 
         count = 0
         for result in self.results.results:
-            if result.severity == constants.ERROR:
+            if result.result == constants.ERROR:
                 count += 1
                 assert result.source == 'ipahealthcheck.system.filesystemspace'
                 assert result.check == 'FileSystemSpaceCheck'
@@ -102,7 +102,7 @@ class TestFileSystemEnoughFreeSpace(BaseTest):
         self.results = capture_results(f)
 
         for result in self.results.results:
-            assert result.severity == constants.SUCCESS
+            assert result.result == constants.SUCCESS
             assert result.source == 'ipahealthcheck.system.filesystemspace'
             assert result.check == 'FileSystemSpaceCheck'
             assert (


### PR DESCRIPTION
My intention originally was to save a few bits but it makes the
output much harder to read than I expected. There is no real
compelling reason to force users to translate on the analysis
end.