### PR TITLE
Return non-zero on error

### DIFF
--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -219,3 +219,11 @@ def main():
         output.render(results)
     except Exception as e:
         logger.error('Output raised %s: %s', e.__class__.__name__, e)
+
+    return_value = 0
+    for result in results.results:
+        if result.severity != constants.SUCCESS:
+            return_value = 1
+            break
+
+    sys.exit(return_value)

--- a/src/ipahealthcheck/ds/replication.py
+++ b/src/ipahealthcheck/ds/replication.py
@@ -26,7 +26,10 @@ class ReplicationConflictCheck(DSPlugin):
     """
     @duration
     def check(self):
-        conn = ipaldap.LDAPClient.from_realm(api.env.realm)
+        try:
+            conn = ipaldap.LDAPClient.from_realm(api.env.realm)
+        except AttributeError:
+            conn = ipaldap.LDAPClient(api.env.ldap_uri)
         conn.external_bind()
 
         filterstr = "(&(!(objectclass=nstombstone))(nsds5ReplConflict=*))"


### PR DESCRIPTION
Fix one check that was failing due to API issue when run using IPA 4.7.2. This failure had the side effect of showing that on failures a non-zero return value wasn't being set. Fix that as well.