### PR TITLE
Include newline in JSON output

### DIFF
--- a/src/ipahealthcheck/core/output.py
+++ b/src/ipahealthcheck/core/output.py
@@ -64,6 +64,8 @@ class JSON(Output):
                 continue
             output.append(line)
         f.write(json.dumps(output, indent=self.indent))
+        if sys.stdout.isatty():
+            f.write('\n')
 
         # Ok, hacky, but using with and stdout will close stdout
         # which could be bad.


### PR DESCRIPTION
This prettifies the output, particularly when going to stdout

https://github.com/freeipa/freeipa-healthcheck/issues/36