### PR TITLE
When reporting certmonger request issues flatten the request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
 
 script:
     - tox -epep8,flake8
-    - docker run -v ${TRAVIS_BUILD_DIR}:/root/src/ fedora:29 /bin/sh -c "dnf -y install freeipa-server tox; cd /root/src; tox -epy3"
+    - docker run -v ${TRAVIS_BUILD_DIR}:/root/src/ fedora:29 /bin/sh -c "dnf -y install freeipa-server tox python3-pytest; cd /root/src; tox -epy3"

--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -435,8 +435,10 @@ class IPACertTracking(IPAPlugin):
 
             # The criteria was not met
             if request_id is None:
+                flatten = ', '.join("{!s}={!s}".format(key, val)
+                                    for (key, val) in request.items())
                 yield Result(self, constants.ERROR,
-                             msg='Missing tracking for %s' % request)
+                             msg='Missing tracking for %s' % flatten)
                 continue
 
         # Report any unknown certmonger requests as warnings

--- a/tests/test_ipa_tracking.py
+++ b/tests/test_ipa_tracking.py
@@ -52,15 +52,15 @@ class TestTracking(BaseTest):
         assert result.severity == constants.ERROR
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPACertTracking'
-        assert result.kw.get('msg') == "Missing tracking for {" \
-            "'cert-file': '/var/lib/ipa/ra-agent.pem', " \
-            "'key-file': '/var/lib/ipa/ra-agent.key', " \
-            "'ca-name': 'dogtag-ipa-ca-renew-agent', " \
-            "'cert-storage': 'FILE', "\
-            "'cert-presave-command': " \
-            "'/usr/libexec/ipa/certmonger/renew_ra_cert_pre', " \
-            "'cert-postsave-command': " \
-            "'/usr/libexec/ipa/certmonger/renew_ra_cert'}"
+        assert result.kw.get('msg') == "Missing tracking for " \
+            "cert-file=/var/lib/ipa/ra-agent.pem, " \
+            "key-file=/var/lib/ipa/ra-agent.key, " \
+            "ca-name=dogtag-ipa-ca-renew-agent, " \
+            "cert-storage=FILE, "\
+            "cert-presave-command=" \
+            "/usr/libexec/ipa/certmonger/renew_ra_cert_pre, " \
+            "cert-postsave-command=" \
+            "/usr/libexec/ipa/certmonger/renew_ra_cert"
 
     def test_unknown_cert_tracking(self):
         # Add a custom, unknown request


### PR DESCRIPTION
This was previously using str() to convert the dict into a string.
In Output this could be passed into string.format() which will
interpret the embedded {} of the dict as variable names.

Instead flatten the dictionary into a comma-separate string of
name/value pairs

https://github.com/freeipa/freeipa-healthcheck/issues/37