### PR TITLE
Travis/tox invocation: add python3-pytest to packages to install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
 
 script:
     - tox -epep8,flake8
-    - docker run -v ${TRAVIS_BUILD_DIR}:/root/src/ fedora:29 /bin/sh -c "dnf -y install freeipa-server tox; cd /root/src; tox -epy3"
+    - docker run -v ${TRAVIS_BUILD_DIR}:/root/src/ fedora:29 /bin/sh -c "dnf -y install freeipa-server tox python3-pytest; cd /root/src; tox -epy3"


### PR DESCRIPTION
```
py3 runtests: commands[0] | /root/src/.tox/py3/bin/python -m pytest
/root/src/.tox/py3/bin/python: No module named pytest
ERROR: InvocationError for command '/root/src/.tox/py3/bin/python -m pytest' (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   py3: commands failed
The command "docker run -v ${TRAVIS_BUILD_DIR}:/root/src/ fedora:29 /bin/sh -c "dnf -y install freeipa-server tox; cd /root/src; tox -epy3"" exited with 1.
```