### PR TITLE
Add service dependencies to checks that rely on services to be up

### DIFF
--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -105,11 +105,14 @@ def run_plugins(plugins, config, available, source, check):
 
         logger.debug('Calling check %s' % plugin)
         plugin.config = config
-        # TODO: make this not the default
         if not set(plugin.requires).issubset(available):
-            result = Result(plugin, constants.ERROR,
-                            msg='%s service(s) not running' %
-                            (', '.join(set(plugin.requires) - available)))
+            logger.debug('Skipping %s:%s because %s service(s) not running',
+                         plugin.__class__.__module__,
+                         plugin.__class__.__name__,
+                         ', '.join(set(plugin.requires) - available))
+            # Not providing a Result in this case because if a required
+            # service isn't available then this could generate a lot of
+            # false positives.
         else:
             for result in run_plugin(plugin, available):
                 results.add(result)

--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -75,13 +75,13 @@ def run_service_plugins(plugins, config, source, check):
         if not isinstance(plugin, ServiceCheck):
             continue
 
-        if not source_or_check_matches(plugin, source, check):
-            continue
-
         logger.debug('Calling check %s', plugin)
         for result in plugin.check():
+            # always run the service checks so dependencies work
             if result is not None and result.result == constants.SUCCESS:
                 available.append(plugin.service.service_name)
+            if not source_or_check_matches(plugin, source, check):
+                continue
             if result is not None:
                 results.add(result)
 

--- a/src/ipahealthcheck/core/output.py
+++ b/src/ipahealthcheck/core/output.py
@@ -60,7 +60,7 @@ class JSON(Output):
         output = []
         for line in data.output():
             result = line.get('result')
-            if self.failures_only and int(result) == SUCCESS:
+            if self.failures_only and result == 'SUCCESS':
                 continue
             output.append(line)
         f.write(json.dumps(output, indent=self.indent))

--- a/src/ipahealthcheck/core/plugin.py
+++ b/src/ipahealthcheck/core/plugin.py
@@ -63,7 +63,7 @@ class Plugin:
     registry defines where the plugin was registered, normally via
     a pkg_resource.
 
-    requires is a set of strings that define pre-requisites for
+    requires is a tuple of strings that define pre-requisites for
     execution. Some output formats allow plugins that do not have
     these requirements met to skip them (JSON does NOT, all plugins
     are always executed and reported).
@@ -94,9 +94,10 @@ class Plugin:
                 return result
 
     """
+    requires = ()
+
     def __init__(self, registry):
         self.registry = registry
-        self.requires = set()
         self.config = dict()
 
 

--- a/src/ipahealthcheck/dogtag/ca.py
+++ b/src/ipahealthcheck/dogtag/ca.py
@@ -94,6 +94,8 @@ class DogtagCertsConnectivityCheck(DogtagPlugin):
     """
     Test basic connectivity by using cert-show to fetch a cert
     """
+    requires = ('dirsrv',)
+
     @duration
     def check(self):
         if not self.ca.is_configured():

--- a/src/ipahealthcheck/ds/replication.py
+++ b/src/ipahealthcheck/ds/replication.py
@@ -24,6 +24,8 @@ class ReplicationConflictCheck(DSPlugin):
     The presence of this indicates a replication error. Report any
     found as errors.
     """
+    requires = ('dirsrv',)
+
     @duration
     def check(self):
         try:

--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -400,6 +400,8 @@ class IPACertTracking(IPAPlugin):
           potential issues.
     """
 
+    requires = ('dirsrv',)
+
     @duration
     def check(self):
         requests = get_expected_requests(self.ca, self.ds, self.serverid)
@@ -650,15 +652,12 @@ class IPARAAgent(IPAPlugin):
        Compare the description and usercertificate values.
     """
 
+    requires = ('dirsrv',)
+
     @duration
     def check(self):
         if not self.ca.is_configured():
             logger.debug('CA is not configured, skipping RA Agent check')
-            return
-
-        if not api.Backend.ldap2.isconnected():
-            yield Result(self, constants.CRITICAL,
-                         msg='Skipping because no LDAP connection')
             return
 
         try:
@@ -754,6 +753,8 @@ class IPACertRevocation(IPAPlugin):
         "privilege withdrawn",
         "AA compromise",
     ]
+
+    requires = ('dirsrv',)
 
     @duration
     def check(self):

--- a/src/ipahealthcheck/ipa/dna.py
+++ b/src/ipahealthcheck/ipa/dna.py
@@ -25,6 +25,8 @@ class IPADNARangeCheck(IPAPlugin):
     if a master does not have a range. It IS an error if no masters have
     a range.
     """
+    requires = ('dirsrv',)
+
     @duration
     def check(self):
         agmt = replication.ReplicationManager(api.env.realm, api.env.host)

--- a/src/ipahealthcheck/ipa/files.py
+++ b/src/ipahealthcheck/ipa/files.py
@@ -60,6 +60,10 @@ class IPAFileCheck(IPAPlugin, FileCheck):
                                 api.env.basedn), [])
         except errors.NotFound:
             return False
+        except AttributeError:
+            logger.debug("LDAP is down, can't tell whether DNS is available."
+                         " Skipping those file checks.")
+            return False
         return True
 
     def check(self):

--- a/src/ipahealthcheck/ipa/host.py
+++ b/src/ipahealthcheck/ipa/host.py
@@ -23,6 +23,8 @@ logger = logging.getLogger()
 @registry
 class IPAHostKeytab(IPAPlugin):
     """Ensure the host keytab can get a TGT"""
+    requires = ('krb5kdc',)
+
     @duration
     def check(self):
         ccache_dir = tempfile.mkdtemp()

--- a/src/ipahealthcheck/ipa/roles.py
+++ b/src/ipahealthcheck/ipa/roles.py
@@ -47,6 +47,8 @@ class IPARenewalMasterCheck(IPAPlugin):
     useful in the context of the ohter masters. Some external
     service is expected to aggregate this.
     """
+    requires = ('dirsrv',)
+
     @duration
     def check(self):
         try:

--- a/src/ipahealthcheck/ipa/topology.py
+++ b/src/ipahealthcheck/ipa/topology.py
@@ -67,6 +67,8 @@ class IPATopologyDomainCheck(IPAPlugin):
             for r in self.report_errors(suffix, result):
                 yield r
 
+    requires = ('dirsrv',)
+
     @duration
     def check(self):
 


### PR DESCRIPTION
Some checks require one or more services to be running in order to execute. Add dependencies on those services so those checks are skipped if the dependency is not running.
For example, if dirsrv is not running there is no point in returning a lot of failures that LDAP can't be contacted.

This also fixes an issue from a previous commit switching to a string result value.