### PR TITLE
Set KRB5CCNAME and KRB5_CLIENT_KTNAME early (#44)

### DIFF
--- a/man/man1/ipa-healthcheck.1
+++ b/man/man1/ipa-healthcheck.1
@@ -19,6 +19,9 @@ Each check will return a result, either a result of WARNING, ERROR or CRITICAL o
 
 Upon failure the output will include the source and check that detected the failure along with a message and name/value pairs indicating the problem. It may very well be that the check can't make a final determination and generally defaults to WARNING if it can't be sure so that it can be examined.
 
+.SS "IMPLEMENTATION DETAILS"
+There is no need for users to authenticate and get a ticket in advance for ipa\-healthcheck to work. Existing tickets will not be used as ipa\-healthcheck will leverage the host keytab and use a temporary credential cache.
+
 .SH "OPTIONS"
 .SS "COMMANDS"
 .TP

--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -4,6 +4,7 @@
 
 import argparse
 import logging
+from os import environ
 import pkg_resources
 import sys
 
@@ -173,6 +174,8 @@ def parse_options(output_registry):
 
 
 def main():
+    environ["KRB5_CLIENT_KTNAME"] = "/etc/krb5.keytab"
+    environ["KRB5CCNAME"] = "MEMORY:"
     framework = object()
     plugins = []
     output = constants.DEFAULT_OUTPUT


### PR DESCRIPTION
When root has an expired kerberos TGT the ipa-healthcheck service fails
with "GSSAPI Error: Unspecified GSS failure (...) (Ticket expired)".
Set KRB5CCNAME to MEMORY just like kadmin does.
This requires in turn setting KRB5_CLIENT_KTNAME to initialize the
credential cache properly.

Signed-off-by: François Cami <fcami@redhat.com>