### PR TITLE
Make input-file globally available

### DIFF
--- a/man/man1/ipa-healthcheck.1
+++ b/man/man1/ipa-healthcheck.1
@@ -48,6 +48,9 @@ The results are displayed as a list of result messages for each check executed i
 \fB\-\-output\-file\fR=\fIFILENAME\fR
 Write the output to this filename rather than stdout.
 .TP
+\fB\-\-input\-file\fR=\fIFILENAME\fR
+Read the results of a previous run and re-display them.
+.TP
 \fB\-\-indent\fR=\fIINDENT\fR
 Pretty\-print the JSON with this indention level. This can make the output more human\-readable.
 

--- a/src/ipahealthcheck/core/output.py
+++ b/src/ipahealthcheck/core/output.py
@@ -5,7 +5,7 @@
 import json
 import sys
 from ipahealthcheck.core.constants import getLevelName, SUCCESS
-from ipahealthcheck.core.plugin import Registry, json_to_results
+from ipahealthcheck.core.plugin import Registry
 
 
 class OutputRegistry(Registry):
@@ -18,15 +18,11 @@ output_registry = OutputRegistry()
 class Output:
     """Base class for writing/displayhing the output of results
 
-       output_only defines whether the tests should be executed.
-       This allows for an existing set of results to be read and
-       displaying using a different output method.
-
        options is a tuple of argparse options that can add
        class-specific options for output.
     """
     def __init__(self, options):
-        self.output_only = False
+        pass
 
     def render(self, data):
         pass
@@ -80,27 +76,13 @@ class Human(Output):
     TODO: Use the logging module?
 
     """
-    options = (
-        ('--input-file', dict(dest='infile', help='File to translate')),
-    )
+    options = ()
 
     def __init__(self, options):
         super(Human, self).__init__(options)
-        self.filename = options.infile
-        if self.filename:
-            self.output_only = True
         self.failures_only = options.failures_only
 
     def render(self, data):
-
-        if self.filename:
-            with open(self.filename, 'r') as f:
-                raw_data = f.read()
-
-            # caller catches exception
-            json_data = json.loads(raw_data)
-            data = json_to_results(json_data)
-
         for line in data.output():
             kw = line.get('kw')
             result = line.get('result')

--- a/src/ipahealthcheck/core/plugin.py
+++ b/src/ipahealthcheck/core/plugin.py
@@ -125,11 +125,11 @@ class Result:
         exception: used when a check raises an exception
     """
     def __init__(self, plugin, result, source=None, check=None,
-                 start=None, **kw):
+                 start=None, duration=None, when=None, **kw):
         self.result = result
         self.kw = kw
-        self.when = generalized_time(datetime.utcnow())
-        self.duration = None
+        self.when = when or generalized_time(datetime.utcnow())
+        self.duration = duration
         self.uuid = str(uuid.uuid4())
         if None not in (check, source):
             self.check = check
@@ -203,8 +203,11 @@ def json_to_results(data):
         result = line.pop('result')
         source = line.pop('source')
         check = line.pop('check')
+        duration = line.pop('duration')
+        when = line.pop('when')
         kw = line.pop('kw')
-        result = Result(None, result, source, check, **kw)
+        result = Result(None, result, source, check, duration=duration,
+                        when=when, **kw)
         results.add(result)
 
     return results


### PR DESCRIPTION
There is value in being able to re-process existing log files for
any output type so move input-file out of Human and process it
in main.

The main difference in processing is where the results come from:
either a file or by running the checks. Post-processing works
the same.

This will allow one to use an existing log to:
- look for only failures
- look at a specific source or check
- output into any format

https://github.com/freeipa/freeipa-healthcheck/issues/50