### PR TITLE
Make --output-file globally available

### DIFF
--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -157,6 +157,8 @@ def parse_options(output_registry):
                         help='Check to execute, e.g. BazCheck')
     parser.add_argument('--output-type', dest='output', choices=output_names,
                         default='json', help='Output method')
+    parser.add_argument('--output-file', dest='outfile', default='/dev/tty',
+                        help='File to store output')
     parser.add_argument('--input-file', dest='infile',
                         help='File to read as input')
     parser.add_argument('--failures-only', dest='failures_only',


### PR DESCRIPTION
There is valid in being able to provide an output file regardless
of the output type so move output-file out of JSON and process it
in the Output class itself.

An Output plugin only needs to implement the generate() method
to provide a string to be written from the available results.

https://github.com/freeipa/freeipa-healthcheck/issues/53