### PR TITLE
Add an option to search by specific failure severity

### DIFF
--- a/man/man1/ipa-healthcheck.1
+++ b/man/man1/ipa-healthcheck.1
@@ -40,7 +40,10 @@ Execute this particular check within a source. A source must be supplied as well
 Set the output type. The default is JSON.
 .TP
 \fB\-\-failures\-only\fR
-Only report failures. Drop the successful results.
+Exclude SUCCESS results on output.
+.TP
+\fB\-\-severity=\fRSEVERITY\fR
+Only report errors in the requested severity of SUCCESS, WARNING, ERROR or CRITICAL. This can be provided multiple times to search on multiple levels.
 .TP
 \fB\-\-debug\fR
 Generate additional debugging output.

--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -163,7 +163,10 @@ def parse_options(output_registry):
                         help='File to read as input')
     parser.add_argument('--failures-only', dest='failures_only',
                         action='store_true', default=False,
-                        help='Exclude SUCCESS result on output')
+                        help='Exclude SUCCESS results on output')
+    parser.add_argument('--severity', dest='severity', action="append",
+                        help='Include only the selected severity(s)',
+                        choices=[key for key in constants._nameToLevel])
     for plugin in output_registry.plugins:
         onelinedoc = plugin.__doc__.split('\n\n', 1)[0].strip()
         group = parser.add_argument_group(plugin.__name__.lower(),

--- a/src/ipahealthcheck/core/output.py
+++ b/src/ipahealthcheck/core/output.py
@@ -3,7 +3,7 @@
 #
 
 import json
-from ipahealthcheck.core.constants import getLevelName
+from ipahealthcheck.core.constants import getLevelName, _nameToLevel, SUCCESS
 from ipahealthcheck.core.plugin import Registry
 
 
@@ -38,6 +38,7 @@ class Output:
     def __init__(self, options):
         self.filename = options.outfile
         self.failures_only = options.failures_only
+        self.severity = options.severity
 
     def render(self, results):
         """Process the results into output"""
@@ -51,14 +52,17 @@ class Output:
             fd.write(output)
 
     def strip_output(self, results):
-        """Strip out SUCCESS results if --failures-only was used
+        """Strip out SUCCESS results if --failures-only or
+           --severity was used
 
            Returns a list of result values.
         """
         output = []
         for line in results.output():
             result = line.get('result')
-            if self.failures_only and getLevelName(result) == 'SUCCESS':
+            if self.failures_only and _nameToLevel.get(result) == SUCCESS:
+                continue
+            if self.severity is not None and result not in self.severity:
                 continue
             output.append(line)
 


### PR DESCRIPTION
A WARNING is not a failure. Drop it from --failures only.

Add an option to search by specific failure severity.