### PR TITLE
Change DNA no range from SUCCESS to WARNING

### DIFF
--- a/src/ipahealthcheck/ipa/dna.py
+++ b/src/ipahealthcheck/ipa/dna.py
@@ -41,9 +41,11 @@ class IPADNARangeCheck(IPAPlugin):
                          next_start=next_start or 0,
                          next_max=next_max or 0)
         else:
-            yield Result(self, constants.SUCCESS,
+            yield Result(self, constants.WARNING,
                          range_start=0,
                          range_max=0,
                          next_start=0,
                          next_max=0,
-                         msg='No range defined')
+                         msg='No DNA range defined. If no masters define a '
+                             'range then users and groups cannot be '
+                             'created.')

--- a/tests/test_ipa_dna.py
+++ b/tests/test_ipa_dna.py
@@ -66,7 +66,7 @@ class TestDNARange(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.result == constants.SUCCESS
+        assert result.result == constants.WARNING
         assert result.source == 'ipahealthcheck.ipa.dna'
         assert result.check == 'IPADNARangeCheck'
         assert result.kw.get('range_start') == 0


### PR DESCRIPTION
Elevate the not set version to WARNING so admins can be aware in
advance that with no range then uid/gid cannot be allocated from
this master. This is particularly important if the only master with
a range defined is retired.

https://github.com/freeipa/freeipa-healthcheck/issues/60