### PR TITLE
Always initialize AD roles even if the IPA API is initialized

### DIFF
--- a/src/ipahealthcheck/ipa/plugin.py
+++ b/src/ipahealthcheck/ipa/plugin.py
@@ -40,15 +40,13 @@ class IPARegistry(Registry):
     def initialize(self, framework):
         installutils.check_server_configuration()
 
-        if api.isdone('finalize'):
-            return
-
-        if not api.isdone('bootstrap'):
-            api.bootstrap(in_server=True,
-                          context='ipahealthcheck',
-                          log=None)
         if not api.isdone('finalize'):
-            api.finalize()
+            if not api.isdone('bootstrap'):
+                api.bootstrap(in_server=True,
+                              context='ipahealthcheck',
+                              log=None)
+            if not api.isdone('finalize'):
+                api.finalize()
 
         if not api.Backend.ldap2.isconnected():
             try:

--- a/src/ipahealthcheck/ipa/plugin.py
+++ b/src/ipahealthcheck/ipa/plugin.py
@@ -12,7 +12,6 @@ from ipaserver.install import cainstance
 from ipaserver.install import dsinstance
 from ipaserver.install import httpinstance
 from ipaserver.install import installutils
-from ipaserver.servroles import ADtrustBasedRole, ServiceBasedRole
 
 from ipahealthcheck.core.plugin import Plugin, Registry
 
@@ -38,6 +37,9 @@ class IPARegistry(Registry):
         self.trust_controller = False
 
     def initialize(self, framework):
+        # deferred import for mock
+        from ipaserver.servroles import ADtrustBasedRole, ServiceBasedRole
+
         installutils.check_server_configuration()
 
         if not api.isdone('finalize'):

--- a/tests/base.py
+++ b/tests/base.py
@@ -17,17 +17,30 @@ class BaseTest(TestCase):
 
     If a test needs a particular value then it will need to use
     @patch individually.
+
+    A default set of Mock patches is set because they apply to all or
+    nearly all test cases.
     """
+    default_patches = {
+        'ipaserver.install.installutils.check_server_configuration':
+        mock.Mock(return_value=None),
+    }
+    patches = {}
 
     def setup_class(self):
         # collect the list of patches to be applied for this class of
         # tests
+        self.default_patches.update(self.patches)
+
         self.applied_patches = [
-            mock.patch(patch, data) for patch, data in self.patches.items()
+            mock.patch(patch, data) for patch, data in
+            self.default_patches.items()
         ]
 
         for patch in self.applied_patches:
             patch.start()
+
+        self.results = None
 
     def teardown_class(self):
         mock.patch.stopall()

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,6 +3,7 @@
 #
 from unittest import mock, TestCase
 from util import no_exceptions
+from util import ADtrustBasedRole, ServiceBasedRole
 
 
 class BaseTest(TestCase):
@@ -24,6 +25,10 @@ class BaseTest(TestCase):
     default_patches = {
         'ipaserver.install.installutils.check_server_configuration':
         mock.Mock(return_value=None),
+        'ipaserver.servroles.ServiceBasedRole':
+        mock.Mock(return_value=ServiceBasedRole()),
+        'ipaserver.servroles.ADtrustBasedRole':
+        mock.Mock(return_value=ADtrustBasedRole()),
     }
     patches = {}
 

--- a/tests/test_dogtag_ca.py
+++ b/tests/test_dogtag_ca.py
@@ -37,8 +37,6 @@ class mock_CertDB:
 
 class TestCACerts(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ipaserver.install.cainstance.CAInstance':
         Mock(return_value=CAInstance()),
         'ipaserver.install.krainstance.KRAInstance':

--- a/tests/test_dogtag_connectivity.py
+++ b/tests/test_dogtag_connectivity.py
@@ -14,8 +14,6 @@ from ipalib.errors import CertificateOperationError
 
 class TestCAConnectivity(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ipaserver.install.cainstance.CAInstance':
         Mock(return_value=CAInstance()),
     }

--- a/tests/test_ds_replication.py
+++ b/tests/test_ds_replication.py
@@ -4,7 +4,7 @@
 
 import pytest
 from base import BaseTest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from util import capture_results, m_api
 
 from ipahealthcheck.core import config, constants
@@ -37,11 +37,6 @@ class mock_ldap:
 
 
 class TestReplicationConflicts(BaseTest):
-    patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
-    }
-
     @pytest.mark.skipif(NUM_VERSION < 40790,
                         reason="no way of currently testing this")
     @patch('ipapython.ipaldap.LDAPClient.from_realm')

--- a/tests/test_ipa_agent.py
+++ b/tests/test_ipa_agent.py
@@ -56,8 +56,6 @@ class mock_ldap_conn:
 class TestNSSAgent(BaseTest):
     cert = IPACertificate()
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ldap.initialize':
         Mock(return_value=mock_ldap_conn()),
         'ipaserver.install.cainstance.CAInstance':

--- a/tests/test_ipa_certfile_expiration.py
+++ b/tests/test_ipa_certfile_expiration.py
@@ -24,8 +24,6 @@ class IPACertificate:
 
 class TestIPACertificateFile(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ipahealthcheck.ipa.certs.get_expected_requests':
         Mock(return_value=get_expected_requests()),
         'ipalib.install.certmonger._cm_dbus_object':

--- a/tests/test_ipa_certmonger_ca.py
+++ b/tests/test_ipa_certmonger_ca.py
@@ -12,8 +12,6 @@ from unittest.mock import Mock, patch
 
 class TestCertmonger(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ipaserver.install.cainstance.CAInstance':
         Mock(return_value=CAInstance()),
     }

--- a/tests/test_ipa_dna.py
+++ b/tests/test_ipa_dna.py
@@ -3,7 +3,7 @@
 #
 
 from base import BaseTest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from util import capture_results
 
 from ipahealthcheck.core import config, constants
@@ -27,11 +27,6 @@ class mock_ReplicationManager:
 
 
 class TestDNARange(BaseTest):
-    patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
-    }
-
     @patch('ipaserver.install.replication.ReplicationManager')
     def test_dnarange_set(self, mock_manager):
         mock_manager.return_value = mock_ReplicationManager(start=1, max=100)

--- a/tests/test_ipa_expiration.py
+++ b/tests/test_ipa_expiration.py
@@ -17,8 +17,6 @@ from datetime import datetime, timedelta, timezone
 
 class TestExpiration(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ipahealthcheck.ipa.certs.get_expected_requests':
         Mock(return_value=get_expected_requests()),
         'ipalib.install.certmonger._cm_dbus_object':

--- a/tests/test_ipa_nssdb.py
+++ b/tests/test_ipa_nssdb.py
@@ -28,8 +28,6 @@ def my_unparse_trust_flags(trust_flags):
 
 class TestNSSDBTrust(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ipaserver.install.cainstance.CAInstance':
         Mock(return_value=CAInstance()),
         'ipapython.certdb.unparse_trust_flags':

--- a/tests/test_ipa_nssdb.py
+++ b/tests/test_ipa_nssdb.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2019 FreeIPA Contributors see COPYING for license
 #
 
-from util import capture_results, CAInstance
+from util import capture_results, CAInstance, KRAInstance
 from base import BaseTest
 from ipahealthcheck.core import config, constants
 from ipahealthcheck.ipa.plugin import registry
@@ -30,6 +30,8 @@ class TestNSSDBTrust(BaseTest):
     patches = {
         'ipaserver.install.cainstance.CAInstance':
         Mock(return_value=CAInstance()),
+        'ipaserver.install.krainstance.KRAInstance':
+        Mock(return_value=KRAInstance(False)),
         'ipapython.certdb.unparse_trust_flags':
         Mock(side_effect=my_unparse_trust_flags),
     }

--- a/tests/test_ipa_nssvalidation.py
+++ b/tests/test_ipa_nssvalidation.py
@@ -19,8 +19,6 @@ class DsInstance:
 
 class TestNSSValidation(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ipahealthcheck.ipa.certs.get_dogtag_cert_password':
         Mock(return_value='foo'),
         'ipaserver.install.dsinstance.DsInstance':

--- a/tests/test_ipa_opensslvalidation.py
+++ b/tests/test_ipa_opensslvalidation.py
@@ -14,8 +14,6 @@ from ipapython.ipautil import _RunResult
 
 class TestOpenSSLValidation(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ipaserver.install.cainstance.CAInstance':
         Mock(return_value=CAInstance()),
     }

--- a/tests/test_ipa_revocation.py
+++ b/tests/test_ipa_revocation.py
@@ -23,8 +23,6 @@ class IPACertificate:
 
 class TestRevocation(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ipaserver.install.certs.is_ipa_issued_cert':
         Mock(return_value=True),
         'ipalib.x509.load_certificate_from_file':

--- a/tests/test_ipa_roles.py
+++ b/tests/test_ipa_roles.py
@@ -3,7 +3,7 @@
 #
 
 from base import BaseTest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from util import capture_results, CAInstance
 from util import m_api
 
@@ -14,11 +14,6 @@ from ipahealthcheck.ipa.roles import (IPACRLManagerCheck,
 
 
 class TestCRLManagerRole(BaseTest):
-    patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
-    }
-
     @patch('ipaserver.install.cainstance.CAInstance')
     def test_not_crlmanager(self, mock_ca):
         mock_ca.return_value = CAInstance(crlgen=False)
@@ -57,11 +52,6 @@ class TestCRLManagerRole(BaseTest):
 
 
 class TestRenewalMaster(BaseTest):
-    patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
-    }
-
     def test_renewal_master_not_set(self):
         framework = object()
         registry.initialize(framework)

--- a/tests/test_ipa_topology.py
+++ b/tests/test_ipa_topology.py
@@ -5,7 +5,6 @@
 from util import capture_results
 from util import m_api
 from base import BaseTest
-from unittest.mock import Mock
 
 from ipahealthcheck.core import config, constants
 from ipahealthcheck.ipa.plugin import registry
@@ -13,11 +12,6 @@ from ipahealthcheck.ipa.topology import IPATopologyDomainCheck
 
 
 class TestTopology(BaseTest):
-    patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
-    }
-
     def test_topology_ok(self):
         m_api.Command.topologysuffix_verify.side_effect = [
             {

--- a/tests/test_ipa_tracking.py
+++ b/tests/test_ipa_tracking.py
@@ -15,8 +15,6 @@ from mock_certmonger import get_expected_requests, set_requests
 
 class TestTracking(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ipahealthcheck.ipa.certs.get_expected_requests':
         Mock(return_value=get_expected_requests()),
         'ipalib.install.certmonger._cm_dbus_object':

--- a/tests/test_ipa_trust.py
+++ b/tests/test_ipa_trust.py
@@ -102,11 +102,6 @@ class SSSDConfig():
 
 
 class TestTrustAgent(BaseTest):
-    patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
-    }
-
     def test_no_trust_agent(self):
         framework = object()
         registry.initialize(framework)
@@ -182,11 +177,6 @@ class TestTrustAgent(BaseTest):
 
 
 class TestTrustDomains(BaseTest):
-    patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
-    }
-
     def test_no_trust_agent(self):
         framework = object()
         registry.initialize(framework)
@@ -371,11 +361,6 @@ class TestTrustDomains(BaseTest):
 
 
 class TestTrustCatalog(BaseTest):
-    patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
-    }
-
     def test_no_trust_agent(self):
         framework = object()
         registry.initialize(framework)
@@ -477,8 +462,6 @@ class TestTrustCatalog(BaseTest):
 
 class Testsidgen(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ldap.initialize':
         Mock(return_value=mock_ldap_conn()),
     }
@@ -562,8 +545,6 @@ class Testsidgen(BaseTest):
 
 class TestTrustAgentMember(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ldap.initialize':
         Mock(return_value=mock_ldap_conn()),
     }
@@ -642,8 +623,6 @@ class TestTrustAgentMember(BaseTest):
 
 class TestControllerPrincipal(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ldap.initialize':
         Mock(return_value=mock_ldap_conn()),
     }
@@ -724,8 +703,6 @@ class TestControllerPrincipal(BaseTest):
 
 class TestControllerService(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ldap.initialize':
         Mock(return_value=mock_ldap_conn()),
     }
@@ -798,8 +775,6 @@ class TestControllerService(BaseTest):
 
 class TestControllerGroupSID(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ldap.initialize':
         Mock(return_value=mock_ldap_conn()),
     }
@@ -877,8 +852,6 @@ class TestControllerGroupSID(BaseTest):
 
 class TestControllerConf(BaseTest):
     patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
         'ldap.initialize':
         Mock(return_value=mock_ldap_conn()),
     }
@@ -922,11 +895,6 @@ class TestControllerConf(BaseTest):
 
 
 class TestPackageCheck(BaseTest):
-    patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
-    }
-
     def test_agent_with_package(self):
         # Note that this test assumes the import is installed
         framework = object()

--- a/tests/test_meta_services.py
+++ b/tests/test_meta_services.py
@@ -7,15 +7,9 @@ from base import BaseTest
 
 from ipahealthcheck.ipa.plugin import registry
 from ipahealthcheck.meta.services import httpd
-from unittest.mock import Mock
 
 
 class TestServices(BaseTest):
-    patches = {
-        'ipaserver.install.installutils.check_server_configuration':
-        Mock(return_value=None),
-    }
-
     def test_simple_service(self):
         """
         Test a service. It was chosen at random.

--- a/tests/util.py
+++ b/tests/util.py
@@ -76,6 +76,33 @@ class KRAInstance:
         return self.installed
 
 
+class ServiceBasedRole:
+    """A bare-bones role override
+
+       This is just enough to satisfy the initialization code so
+       the AD Trust status can be determined. It will always default
+       to false and the registry should be overridden directly in the
+       test cases.
+    """
+    def __init__(self, attr_name=None, name=None, component_services=None):
+        pass
+
+    def status(self, api_instance, server=None, attrs_list=("*",)):
+        return [dict()]
+
+
+class ADtrustBasedRole(ServiceBasedRole):
+    """A bare-bones role override
+
+       This is just enough to satisfy the initialization code so
+       the AD Trust status can be determined. It will always default
+       to false and the registry should be overridden directly in the
+       test cases.
+    """
+    def __init__(self, attr_name=None, name=None):
+        pass
+
+
 # Mock api. This file needs to be imported before anything that would
 # import ipalib.api in order for it to be replaced properly.
 


### PR DESCRIPTION
The setting of these roles in the registry were guarded by whether the IPA API was initialized. If another plugin intialized the API then these values weren't being set, effectively disabling the AD Trust checks.
  
https://github.com/freeipa/freeipa-healthcheck/issues/62
