### PR TITLE
Enhance man page with a pointer to README.md and websites

### DIFF
--- a/man/man1/ipa-healthcheck.1
+++ b/man/man1/ipa-healthcheck.1
@@ -101,3 +101,11 @@ Display in human\-readble output a previous report:
 0 if all checks were successful
 
 1 if any one check failed or the command failed to execute properly
+
+.SH INTERNET RESOURCES
+Main website:  https://www.freeipa.org/
+
+Git repository for ipa-healthcheck:  https://www.github.com/freeipa/freeipa-healthcheck/
+
+.SH OTHER RESOURCES
+The ipa-healthcheck distribution includes a documentation file named README.md which contains detailed explanations on executed checks.


### PR DESCRIPTION
Add a note to ipa-healthcheck(1) so that users find README.md which contains detailed information about executed checks.
