### PR TITLE
Lookup AD user by SID and not by hardcoded username

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
 
 script:
     - tox -epep8,flake8
-    - docker run -v ${TRAVIS_BUILD_DIR}:/root/src/ fedora:29 /bin/sh -c "dnf -y install freeipa-server tox python3-pytest; cd /root/src; tox -epy3"
+    - docker run -v ${TRAVIS_BUILD_DIR}:/root/src/ fedora:29 /bin/sh -c "dnf -y install freeipa-server freeipa-server-trust-ad tox python3-pytest; cd /root/src; tox -epy3"

--- a/src/ipahealthcheck/ipa/plugin.py
+++ b/src/ipahealthcheck/ipa/plugin.py
@@ -57,6 +57,14 @@ class IPARegistry(Registry):
                 logging.debug('Failed to connect to LDAP: %s', e)
             return
 
+        # This package is pulled in when the trust package is installed
+        # and is required to lookup trust users. If this is not installed
+        # then it can be inferred that trust is not enabled.
+        try:
+            import pysss_nss_idmap  # noqa: F401
+        except ImportError:
+            return
+
         roles = (
             ADtrustBasedRole(u"ad_trust_agent_server",
                              u"AD trust agent"),

--- a/src/ipahealthcheck/ipa/trust.py
+++ b/src/ipahealthcheck/ipa/trust.py
@@ -127,9 +127,9 @@ class IPATrustDomainsCheck(IPAPlugin):
         if result.returncode != 0:
             yield Result(self, constants.ERROR,
                          key='domain_list_error',
-                         sslctl=paths.SSSCTL,
+                         sssctl=paths.SSSCTL,
                          error=result.error_log,
-                         msg='Execution of {sslctl} failed: {error}')
+                         msg='Execution of {sssctl} failed: {error}')
             return
         sssd_domains = result.output.strip().split('\n')
         if 'implicit_files' in sssd_domains:
@@ -152,8 +152,8 @@ class IPATrustDomainsCheck(IPAPlugin):
         else:
             yield Result(self, constants.ERROR,
                          key=api.env.domain,
-                         sslctl=paths.SSSCTL,
-                         msg='{key} not in {sslctl} domain-list')
+                         sssctl=paths.SSSCTL,
+                         msg='{key} not in {sssctl} domain-list')
 
         trust_domains_out = ', '.join(trust_domains)
         sssd_domains_out = ', '.join(sssd_domains)
@@ -161,10 +161,10 @@ class IPATrustDomainsCheck(IPAPlugin):
         if set(trust_domains).symmetric_difference(set(sssd_domains)):
             yield Result(self, constants.ERROR,
                          key='domain-list',
-                         sslctl=paths.SSSCTL,
+                         sssctl=paths.SSSCTL,
                          sssd_domains=sssd_domains_out,
                          trust_domains=trust_domains_out,
-                         msg='{sslctl} {key} reports mismatch: '
+                         msg='{sssctl} {key} reports mismatch: '
                          'sssd domains {sssd_domains} '
                          'trust domains {trust_domains}')
         else:


### PR DESCRIPTION
Looking up the user user as Administrator@REALM is not
portable because the administrator login name may be
localized.