### PR TITLE
Check the CA chain in /etc/ipa/ca.crt for expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,38 @@ Expiring certificate:
       }
     }
 
+### IPACAChainExpirationCheck
+
+Load the CA chain from /etc/ipa/ca.crt and test each one for expiration. This test is designed to ensure that the entire CA chain for all certificates is validated. For example, if the web or LDAP certificates have been replaced then the CA chain for those certs will reside in /etc/ipa/ca.crt. This includes an IPA CA signed by an external authority.
+
+Expiring certificate:
+
+    {
+      "source": "ipahealthcheck.ipa.certs",
+      "check": "IPACAChainExpirationCheck",
+      "result": "WARNING",
+      "kw": {
+        "path": "/etc/ipa/ca.crt",
+        "key": "CN=Certificate Authority,O=EXAMPLE.TEST",
+        "days": 2,
+        "msg": "CA '{key}' is expiring in {days} days."
+      }
+    }
+
+Expired certificate:
+
+    {
+      "source": "ipahealthcheck.ipa.certs",
+      "check": "IPACAChainExpirationCheck",
+      "result": "CRITICAL",
+      "kw": {
+        "path": "/etc/ipa/ca.crt",
+        "key": "CN=Certificate Authority,O=EXAMPLE.TEST",
+        "msg": "CA '{key}' is expired."
+      }
+    }
+
+
 ### IPACertTracking
 Compares the certmonger tracking on the system to the expected values. A query of the expected name/value pairs in certmonger is done to certmonger. On failure the contents of the query are missing. This result would be seen either if the certificate is tracked but there is some slight change in the expected value or if the tracking is missing entirely.
 

--- a/tests/test_ipa_expiration.py
+++ b/tests/test_ipa_expiration.py
@@ -8,7 +8,8 @@ from ipaplatform.paths import paths
 from ipahealthcheck.core import config, constants
 from ipahealthcheck.ipa.plugin import registry
 from ipahealthcheck.ipa.certs import IPACertmongerExpirationCheck
-from unittest.mock import Mock
+from ipahealthcheck.ipa.certs import IPACAChainExpirationCheck
+from unittest.mock import Mock, patch
 from mock_certmonger import create_mock_dbus, _certmonger
 from mock_certmonger import get_expected_requests, set_requests
 
@@ -86,3 +87,175 @@ class TestExpiration(BaseTest):
         assert result.check == 'IPACertmongerExpirationCheck'
         assert result.kw.get('key') == '7777'
         assert 'expires in 19 days' in result.kw.get('msg')
+
+
+class FakeIPACertificate:
+    def __init__(self, cert, backend=None, subject=None, not_after=None):
+        self.subj = subject
+        self.not_after = not_after
+
+    @property
+    def subject(self):
+        return self.subj
+
+    @property
+    def not_valid_after(self):
+        return self.not_after
+
+
+class TestChainExpiration(BaseTest):
+    root_ca = 'CN=Certificate Shack Root CA,O=Certificate Shack Ltd'
+    sub_ca = 'CN=Certificate Shack Intermediate CA,O=Certificate Shack Ltd'
+
+    @patch('ipalib.x509.load_certificate_list_from_file')
+    def test_still_valid(self, mock_load):
+        mock_load.return_value = [
+            FakeIPACertificate(
+                None,
+                subject=self.sub_ca,
+                not_after=datetime.now(timezone.utc) + timedelta(days=20)
+            ),
+            FakeIPACertificate(
+                None,
+                subject=self.root_ca,
+                not_after=datetime.now(timezone.utc) + timedelta(days=20)
+            )
+        ]
+        framework = object()
+        registry.initialize(framework)
+        f = IPACAChainExpirationCheck(registry)
+
+        f.config = config.Config()
+        f.config.cert_expiration_days = 7
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPACAChainExpirationCheck'
+        assert result.kw.get('key') == self.sub_ca
+
+        result = self.results.results[1]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPACAChainExpirationCheck'
+        assert result.kw.get('key') == self.root_ca
+
+    @patch('ipalib.x509.load_certificate_list_from_file')
+    def test_expiring_soon(self, mock_load):
+        mock_load.return_value = [
+            FakeIPACertificate(
+                None,
+                subject=self.sub_ca,
+                not_after=datetime.now(timezone.utc) +
+                timedelta(days=3, minutes=1)
+            ),
+            FakeIPACertificate(
+                None,
+                subject=self.root_ca,
+                not_after=datetime.now(timezone.utc) +
+                timedelta(days=3, minutes=1)
+            )
+        ]
+        framework = object()
+        registry.initialize(framework)
+        f = IPACAChainExpirationCheck(registry)
+
+        f.config = config.Config()
+        f.config.cert_expiration_days = 7
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+
+        result = self.results.results[0]
+        assert result.result == constants.WARNING
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPACAChainExpirationCheck'
+        assert result.kw.get('key') == self.sub_ca
+        assert result.kw.get('days') == 3
+        assert 'expiring' in result.kw.get('msg')
+
+        result = self.results.results[1]
+        assert result.result == constants.WARNING
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPACAChainExpirationCheck'
+        assert result.kw.get('key') == self.root_ca
+        assert result.kw.get('days') == 3
+        assert 'expiring' in result.kw.get('msg')
+
+    @patch('ipalib.x509.load_certificate_list_from_file')
+    def test_all_expired(self, mock_load):
+        mock_load.return_value = [
+            FakeIPACertificate(
+                None,
+                subject=self.sub_ca,
+                not_after=datetime.now(timezone.utc) + timedelta(days=-3)
+            ),
+            FakeIPACertificate(
+                None,
+                subject=self.root_ca,
+                not_after=datetime.now(timezone.utc) + timedelta(days=-3)
+            )
+        ]
+        framework = object()
+        registry.initialize(framework)
+        f = IPACAChainExpirationCheck(registry)
+
+        f.config = config.Config()
+        f.config.cert_expiration_days = 7
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+
+        result = self.results.results[0]
+        assert result.result == constants.CRITICAL
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPACAChainExpirationCheck'
+        assert result.kw.get('key') == self.sub_ca
+        assert 'expired' in result.kw.get('msg')
+
+        result = self.results.results[1]
+        assert result.result == constants.CRITICAL
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPACAChainExpirationCheck'
+        assert result.kw.get('key') == self.root_ca
+        assert 'expired' in result.kw.get('msg')
+
+    @patch('ipalib.x509.load_certificate_list_from_file')
+    def test_one_expired(self, mock_load):
+        mock_load.return_value = [
+            FakeIPACertificate(
+                None,
+                subject=self.sub_ca,
+                not_after=datetime.now(timezone.utc) + timedelta(days=-3)
+            ),
+            FakeIPACertificate(
+                None,
+                subject=self.root_ca,
+                not_after=datetime.now(timezone.utc) + timedelta(days=20)
+            )
+        ]
+        framework = object()
+        registry.initialize(framework)
+        f = IPACAChainExpirationCheck(registry)
+
+        f.config = config.Config()
+        f.config.cert_expiration_days = 7
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+
+        result = self.results.results[0]
+        assert result.result == constants.CRITICAL
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPACAChainExpirationCheck'
+        assert result.kw.get('key') == self.sub_ca
+        assert 'expired' in result.kw.get('msg')
+
+        result = self.results.results[1]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPACAChainExpirationCheck'
+        assert result.kw.get('key') == self.root_ca


### PR DESCRIPTION
The current CA chain is stored into /etc/ipa/ca.crt so we can
use that to pretty easily load all known CA's and check for
expiration.

This can produce three possible outcomes for each cert checked:

1. The certificate is valid thru config.cert_expiration_days
2. The certificate expires in less than config.cert_expiration_days
3. The certificate is expired

This is a replacement for PR ttps://github.com/freeipa/freeipa-healthcheck/pull/34