### PR TITLE
Use sys.stdout by default as /dev/tty does not always exist (#71)

### DIFF
--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -157,7 +157,7 @@ def parse_options(output_registry):
                         help='Check to execute, e.g. BazCheck')
     parser.add_argument('--output-type', dest='output', choices=output_names,
                         default='json', help='Output method')
-    parser.add_argument('--output-file', dest='outfile', default='/dev/tty',
+    parser.add_argument('--output-file', dest='outfile', default=None,
                         help='File to store output')
     parser.add_argument('--input-file', dest='infile',
                         help='File to read as input')

--- a/src/ipahealthcheck/core/output.py
+++ b/src/ipahealthcheck/core/output.py
@@ -3,6 +3,7 @@
 #
 
 import json
+import sys
 from ipahealthcheck.core.constants import getLevelName, _nameToLevel, SUCCESS
 from ipahealthcheck.core.plugin import Registry
 
@@ -29,8 +30,7 @@ class Output:
        2. Generate a string to be written (generate)
        3. Write to the requested file or stdout (write_file)
 
-       stdout == /dev/tty in this case. By using /dev/tty instead
-       of sys.stdout we avoid worrying about closing the fd.
+       stdout == sys.stdout by default.
 
        An Output class only needs to implement the generate() method
        which will render the results into a string for writing.
@@ -47,9 +47,12 @@ class Output:
         self.write_file(output)
 
     def write_file(self, output):
-        """Write the output to a file or /dev/tty"""
-        with open(self.filename, 'w') as fd:
-            fd.write(output)
+        """Write the output to a file or sys.stdout"""
+        if self.filename:
+            with open(self.filename, 'w') as fd:
+                fd.write(output)
+        else:
+            sys.stdout.write(output)
 
     def strip_output(self, results):
         """Strip out SUCCESS results if --failures-only or
@@ -94,7 +97,7 @@ class JSON(Output):
 
     def generate(self, data):
         output = json.dumps(data, indent=self.indent)
-        if self.filename == '/dev/tty':
+        if self.filename is None:
             output += '\n'
 
         return output


### PR DESCRIPTION
Healthcheck currently defaults to using /dev/tty.
/dev/tty does not exist when launching commands non-interactively,
for instance with ssh:
$ ssh root@ipa.test ipa-healthcheck
Output raised OSError: [Errno 6] No such device or address: '/dev/tty'

Switch to using sys.stdout in write_file() when --output-file is
not used.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/71
Signed-off-by: François Cami <fcami@redhat.com>