### PR TITLE
Report the CS and DS RUV values

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         # plugin modules for ipahealthcheck.ds registry
         'ipahealthcheck.ds': [
             'dsreplication = ipahealthcheck.ds.replication',
+            'dsruv = ipahealthcheck.ds.ruv',
         ],
         # plugin modules for ipahealthcheck.system registry
         'ipahealthcheck.system': [

--- a/src/ipahealthcheck/ds/plugin.py
+++ b/src/ipahealthcheck/ds/plugin.py
@@ -12,6 +12,7 @@ class DSPlugin(Plugin):
     def __init__(self, registry):
         super(DSPlugin, self).__init__(registry)
         self.ds = self.ds = dsinstance.DsInstance()
+        self.conn = api.Backend.ldap2
 
 
 class DSRegistry(Registry):

--- a/src/ipahealthcheck/ds/ruv.py
+++ b/src/ipahealthcheck/ds/ruv.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+import logging
+
+from ipahealthcheck.ds.plugin import DSPlugin, registry
+from ipahealthcheck.core.plugin import Result
+from ipahealthcheck.core.plugin import duration
+from ipahealthcheck.core import constants
+
+from ipalib import api
+from ipapython.dn import DN
+
+logger = logging.getLogger()
+
+
+@registry
+class RUVCheck(DSPlugin):
+    """
+    Provide the main and dogtag RUV.
+
+    Local analysis is not possible since it requires collecting the
+    RUV from all masters and healthcheck is limited to only talking
+    to itself.
+    """
+    requires = ('dirsrv',)
+
+    def get_ruv(self, dn):
+        try:
+            entry = self.conn.get_entry(dn)
+        except Exception:
+            return None
+        else:
+            return entry.single_value.get('nsDS5ReplicaID')
+
+    @duration
+    def check(self):
+        ruv = self.get_ruv(DN(('cn', 'replica'), ('cn', api.env.basedn),
+                           ('cn', 'mapping tree'), ('cn', 'config')))
+        csruv = self.get_ruv(DN(('cn', 'replica'), ('cn', 'o=ipaca'),
+                             ('cn', 'mapping tree'), ('cn', 'config')))
+
+        if ruv is not None:
+            yield Result(self, constants.SUCCESS,
+                         key=str(api.env.basedn),
+                         ruv=ruv)
+        if csruv is not None:
+            yield Result(self, constants.SUCCESS,
+                         key='o=ipaca',
+                         ruv=csruv)

--- a/tests/test_ds_ruv.py
+++ b/tests/test_ds_ruv.py
@@ -1,0 +1,140 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+from base import BaseTest
+from unittest.mock import Mock
+from util import capture_results, m_api
+
+from ipahealthcheck.core import config, constants
+from ipahealthcheck.ds.plugin import registry
+from ipahealthcheck.ds.ruv import RUVCheck
+
+from ipalib import errors
+from ipapython.dn import DN
+from ipapython.ipaldap import LDAPClient, LDAPEntry
+
+
+class mock_ldap:
+    SCOPE_BASE = 1
+    SCOPE_ONELEVEL = 2
+    SCOPE_SUBTREE = 4
+
+    def __init__(self, ldapentry):
+        """Initialize the results that we will return from get_entries"""
+        self.results = ldapentry
+        self.index = 0
+
+    def get_entry(self, dn, attrs_list=None, time_limit=None,
+                  size_limit=None, get_effective_rights=False):
+        if len(self.results) == 0:
+            raise errors.NotFound(reason='test')
+        self.index += 1
+        if self.results[self.index - 1] is None:
+            raise errors.NotFound(reason='test')
+        return self.results[self.index - 1]
+
+
+class mock_ldap_conn:
+    def set_option(self, option, invalue):
+        pass
+
+    def search_s(self, base, scope, filterstr=None,
+                 attrlist=None, attrsonly=0):
+        return tuple()
+
+
+class TestRUV(BaseTest):
+    patches = {
+        'ldap.initialize':
+        Mock(return_value=mock_ldap_conn()),
+    }
+
+    def create_entry(self, conn, dn, attrs):
+        """Create an LDAPEntry object from the provided dn and attrs
+           dn: DN() object
+           attrs: dict of name/value pairs of LDAP attributes
+        """
+        ldapentry = LDAPEntry(conn, dn)
+        for attr, values in attrs.items():
+            ldapentry[attr] = values
+
+        return ldapentry
+
+    def test_no_ruvs(self):
+        framework = object()
+        registry.initialize(framework)
+        f = RUVCheck(registry)
+
+        f.conn = mock_ldap(None)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 0
+
+    def test_both_ruvs(self):
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        entries = []
+
+        entries.append(
+            self.create_entry(fake_conn,
+                              DN('dc=example,cn=mapping tree,cn=config'),
+                              {'nsds5ReplicaId': ['3']})
+        )
+        entries.append(
+            self.create_entry(fake_conn,
+                              DN('o=ipaca,cn=mapping tree,cn=config'),
+                              {'nsds5ReplicaId': ['5']})
+        )
+
+        framework = object()
+        registry.initialize(framework)
+        f = RUVCheck(registry)
+
+        f.conn = mock_ldap(entries)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ds.ruv'
+        assert result.check == 'RUVCheck'
+        assert result.kw.get('key') == str(m_api.env.basedn)
+        assert result.kw.get('ruv') == '3'
+
+        result = self.results.results[1]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ds.ruv'
+        assert result.check == 'RUVCheck'
+        assert result.kw.get('key') == 'o=ipaca'
+        assert result.kw.get('ruv') == '5'
+
+    def test_one_ruvs(self):
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        entries = []
+
+        entries.append(
+            self.create_entry(fake_conn,
+                              DN('dc=example,cn=mapping tree,cn=config'),
+                              {'nsds5ReplicaId': ['3']})
+        )
+        entries.append(None)
+
+        framework = object()
+        registry.initialize(framework)
+        f = RUVCheck(registry)
+
+        f.conn = mock_ldap(entries)
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ds.ruv'
+        assert result.check == 'RUVCheck'
+        assert result.kw.get('key') == str(m_api.env.basedn)
+        assert result.kw.get('ruv') == '3'


### PR DESCRIPTION
It isn't possible to identify dangling RUVs since healthcheck
runs locally only. The best we can do is report the current
value(s).

https://github.com/freeipa/freeipa-healthcheck/issues/30