### PR TITLE
Validate expected DNS SRV records based on server roles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'ipahealthcheck.ipa': [
             'ipacerts = ipahealthcheck.ipa.certs',
             'ipadna = ipahealthcheck.ipa.dna',
+            'ipadns = ipahealthcheck.ipa.dns',
             'ipafiles = ipahealthcheck.ipa.files',
             'ipahost = ipahealthcheck.ipa.host',
             'iparoles = ipahealthcheck.ipa.roles',

--- a/src/ipahealthcheck/ipa/dns.py
+++ b/src/ipahealthcheck/ipa/dns.py
@@ -1,0 +1,150 @@
+
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+from dns import rdatatype
+from dns.exception import DNSException
+import logging
+
+from ipahealthcheck.ipa.plugin import IPAPlugin, registry
+from ipahealthcheck.core.plugin import Result, duration
+from ipahealthcheck.core import constants
+
+from ipalib import api
+from dns import resolver
+
+
+logger = logging.getLogger()
+
+
+@registry
+class IPADNSSystemRecordsCheck(IPAPlugin):
+    """
+    Verify that the expected DNS service records are resolvable.
+
+    IPA will already provide the values we need to validate with the
+    IPASystemRecords class. We just need to pull that and do the
+    equivalent DNS lookups.
+    """
+    requires = ('dirsrv',)
+
+    def srv_to_name(self, srv, target):
+        """Combine the SRV record and target into a unique name."""
+        return srv + ":" + target
+
+    @duration
+    def check(self):
+        from ipapython.dnsutil import query_srv
+        from ipaserver.dns_data_management import IPASystemRecords
+
+        system_records = IPASystemRecords(api)
+        base_records = system_records.get_base_records()
+
+        # collect the list of expected values
+        txt_rec = dict()
+        srv_rec = dict()
+        a_rec = list()
+
+        for name, node in base_records.items():
+            for rdataset in node:
+                for rd in rdataset:
+                    if rd.rdtype == rdatatype.SRV:
+                        if name.ToASCII() in srv_rec:
+                            srv_rec[name.ToASCII()].append(rd.target.to_text())
+                        else:
+                            srv_rec[name.ToASCII()] = [rd.target.to_text()]
+                    elif rd.rdtype == rdatatype.TXT:
+                        if name.ToASCII() in txt_rec:
+                            txt_rec[name.ToASCII()].append(rd.to_text())
+                        else:
+                            txt_rec[name.ToASCII()] = [rd.to_text()]
+                    elif rd.rdtype == rdatatype.A:
+                        a_rec.append(rd.to_text())
+                    else:
+                        logger.error("Unhandler rdtype %d", rd.rdtype)
+
+        # For each SRV record that IPA thinks it should have, do a DNS
+        # lookup of it and ensure that DNS has the same set of values
+        # that IPA thinks it should.
+        for srv in srv_rec:
+            logger.debug("Search DNS for SRV record of %s", srv)
+            try:
+                answers = query_srv(srv)
+            except DNSException as e:
+                logger.debug("DNS record not found: %s", e.__class__.__name__)
+                answers = []
+            hosts = srv_rec[srv]
+            for answer in answers:
+                logger.debug("DNS record found: %s", answer)
+                try:
+                    hosts.remove(answer.target.to_text())
+                    yield Result(
+                         self, constants.SUCCESS,
+                         key=self.srv_to_name(srv, answer.target.to_text()))
+                except ValueError:
+                    yield Result(
+                        self, constants.WARNING,
+                        msg='Unexpected SRV entry in DNS',
+                        key=self.srv_to_name(srv, answer.target.to_text()))
+            for host in hosts:
+                yield Result(
+                    self, constants.WARNING,
+                    msg='Expected SRV record missing',
+                    key=self.srv_to_name(srv, host))
+
+        for txt in txt_rec:
+            logger.debug("Search DNS for TXT record of %s", txt)
+            try:
+                answers = resolver.query(txt, rdatatype.TXT)
+            except DNSException as e:
+                logger.debug("DNS record not found: %s", e.__class__.__name__)
+                answers = []
+
+            realms = txt_rec[txt]
+            for answer in answers:
+                logger.debug("DNS record found: %s", answer)
+                realm = answer.to_text()
+                try:
+                    realms.remove(realm)
+                    yield Result(self, constants.SUCCESS,
+                                 key=realm)
+                except ValueError:
+                    yield Result(self, constants.WARNING,
+                                 key=realm,
+                                 msg='expected realm missing')
+
+        # Look up the ipa-ca records
+        qname = "ipa-ca." + api.env.domain + "."
+        logger.debug("Search DNS for A record of %s", qname)
+
+        try:
+            answers = resolver.query(qname, rdatatype.A)
+        except DNSException as e:
+            logger.debug("DNS record not found: %s", e.__class__.__name__)
+            answers = []
+
+        hosts = a_rec
+        for answer in answers:
+            logger.debug("DNS record found: %s", answer)
+            ipaddr = answer.to_text()
+            try:
+                a_rec.remove(ipaddr)
+                yield Result(self, constants.SUCCESS,
+                             key=ipaddr)
+            except ValueError:
+                yield Result(self, constants.WARNING,
+                             key=ipaddr,
+                             msg='expected ipa-ca IPAddr missing')
+
+        ca_count = 0
+        for server in system_records.servers_data:
+            master = system_records.servers_data.get(server)
+            if 'CA server' in master.get('roles'):
+                ca_count += 1
+
+        if len(answers) != ca_count:
+            yield Result(
+                self, constants.WARNING,
+                msg='Got {count} ipa-ca A records, expected {expected}',
+                count=len(answers),
+                expected=ca_count)

--- a/tests/test_ipa_dns.py
+++ b/tests/test_ipa_dns.py
@@ -1,0 +1,595 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+from dns import (
+    rdata,
+    rdataclass,
+    rdatatype,
+    message,
+    rrset,
+)
+from dns.resolver import Answer, NoAnswer
+
+from base import BaseTest
+from util import capture_results, m_api
+from unittest.mock import patch
+
+from ipahealthcheck.core import config, constants
+from ipahealthcheck.ipa.plugin import registry
+from ipahealthcheck.ipa.dns import IPADNSSystemRecordsCheck
+
+from ipapython.dnsutil import DNSName
+from ipaserver.dns_data_management import (
+    IPA_DEFAULT_MASTER_SRV_REC,
+    IPA_DEFAULT_ADTRUST_SRV_REC
+)
+
+
+def add_srv_records(qname, port_map, priority=0, weight=100):
+    rdlist = []
+    for name, port in port_map:
+        answerlist = []
+        for host in qname:
+            hostname = DNSName(host)
+            rd = rdata.from_text(
+                rdataclass.IN, rdatatype.SRV,
+                '{0} {1} {2} {3}'.format(
+                    priority, weight, port, hostname.make_absolute()
+                )
+            )
+            answerlist.append(rd)
+        rdlist.append(answerlist)
+    return rdlist
+
+
+def query_srv(qname, ad_records=False):
+    """
+    Return a SRV for each service IPA cares about for all the hosts.
+
+    This is pre-generated as a side-effect for each test.
+    """
+    rdlist = add_srv_records(qname, IPA_DEFAULT_MASTER_SRV_REC)
+    if ad_records:
+        rdlist.extend(add_srv_records(qname, IPA_DEFAULT_ADTRUST_SRV_REC))
+    return rdlist
+
+
+class Response:
+    """Fake class so that a DNS NoAnswer can be raised"""
+    def __init__(self, question=None):
+        self.question = question
+
+    @property
+    def question(self):
+        return self.__question
+
+    @question.setter
+    def question(self, question):
+        self.__question = question
+
+
+def gen_addrs(num):
+    """Generate sequential IP addresses for the ipa-ca A record lookup"""
+    ips = []
+    for i in range(num):
+        ips.append('192.168.0.%d' % (i + 1))
+
+    return ips
+
+
+def fake_query(qname, rdtype=rdatatype.A, rdclass=rdataclass.IN, count=1,
+               fake_txt=False):
+    """Fake a DNS query, returning count responses to the request
+
+       Three kinds of lookups are faked:
+       1. A query for A records for a service will return the count
+          as requested in the test. This simulates lookups for the
+          ipa-ca A record. To force a difference in responses one can
+          vary the count.
+       2. AAAA records are not yet supported, return no answer
+       3. TXT queries will return the Kerberos realm
+
+       fake_txt will set an invalid Kerberos realm entry to provoke a
+       warning.
+    """
+    m = message.Message()
+    if rdtype == rdatatype.A:
+        fqdn = DNSName(qname)
+        fqdn = fqdn.make_absolute()
+
+        answers = Answer(fqdn, rdataclass.IN, rdatatype.A, m,
+                         raise_on_no_answer=False)
+
+        rlist = rrset.from_text_list(fqdn, 86400, rdataclass.IN,
+                                     rdatatype.A, gen_addrs(count))
+
+        answers.rrset = rlist
+    elif rdtype == rdatatype.AAAA:
+        raise NoAnswer(response=Response('no AAAA'))
+    elif rdtype == rdatatype.TXT:
+        if fake_txt:
+            realm = 'FAKE_REALM'
+        else:
+            realm = m_api.env.realm
+        qname = DNSName('_kerberos.' + m_api.env.domain)
+        qname = qname.make_absolute()
+
+        answers = Answer(qname, rdataclass.IN, rdatatype.TXT, m,
+                         raise_on_no_answer=False)
+
+        rlist = rrset.from_text_list(qname, 86400, rdataclass.IN,
+                                     rdatatype.TXT, [realm])
+
+        answers.rrset = rlist
+
+    return answers
+
+
+# Helpers to generate an appropriate number of A records for the
+# ipa-ca and Kerberos realm responses. Optionally return a bogus
+# TXT record.
+def fake_query_one(qname, rdtype=rdatatype.A, rdclass=rdataclass.IN,
+                   count=1):
+    return fake_query(qname, rdtype, rdclass, count)
+
+
+def fake_query_two(qname, rdtype=rdatatype.A, rdclass=rdataclass.IN,
+                   count=2):
+    return fake_query(qname, rdtype, rdclass, count)
+
+
+def fake_query_three(qname, rdtype=rdatatype.A, rdclass=rdataclass.IN,
+                     count=3):
+    return fake_query(qname, rdtype, rdclass, count)
+
+
+def fake_query_one_txt(qname, rdtype=rdatatype.A, rdclass=rdataclass.IN,
+                       count=1):
+    return fake_query(qname, rdtype, rdclass, count, fake_txt=True)
+
+
+def get_results_by_severity(results, severity):
+    """Return the results with a matching severity"""
+    new_results = []
+    for result in results:
+        if result.result == severity:
+            new_results.append(result)
+    return new_results
+
+
+class TestDNSSystemRecords(BaseTest):
+    """Test that the SRV records checks are working properly
+
+       The intention was to not override IPASystemRecords since
+       this is the core mechanism that IPA uses to determine what
+       recoreds should exist.
+
+       Instead the DNS lookups are managed. This is done in two
+       ways:
+
+       1. The query_srv() override returns the set of configured
+          servers for each type of SRV record.
+       2. fake_query() overrides dns.resolver.query to simulate
+          A, AAAA and TXT record lookups.
+    """
+    @patch('ipapython.dnsutil.query_srv')
+    @patch('dns.resolver.query')
+    def test_dnsrecords_single(self, mock_query, mock_query_srv):
+        """Test single CA master, all SRV records"""
+        mock_query.side_effect = fake_query_one
+        mock_query_srv.side_effect = query_srv([m_api.env.host])
+
+        m_api.Command.server_find.side_effect = [{
+            'result': [
+                {
+                    'cn': [m_api.env.host],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+            ]
+        }]
+        framework = object()
+        registry.initialize(framework)
+        f = IPADNSSystemRecordsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 9
+
+        for result in self.results.results:
+            assert result.result == constants.SUCCESS
+            assert result.source == 'ipahealthcheck.ipa.dns'
+            assert result.check == 'IPADNSSystemRecordsCheck'
+
+    @patch('ipapython.dnsutil.query_srv')
+    @patch('dns.resolver.query')
+    def test_dnsrecords_two(self, mock_query, mock_query_srv):
+        """Test two CA masters, all SRV records"""
+        mock_query_srv.side_effect = query_srv([
+            m_api.env.host,
+            'replica.' + m_api.env.domain
+        ])
+        mock_query.side_effect = fake_query_two
+
+        m_api.Command.server_find.side_effect = [{
+            'result': [
+                {
+                    'cn': [m_api.env.host],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+                {
+                    'cn': ['replica.' + m_api.env.domain],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+            ]
+        }]
+
+        framework = object()
+        registry.initialize(framework)
+        f = IPADNSSystemRecordsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 17
+
+        for result in self.results.results:
+            assert result.result == constants.SUCCESS
+            assert result.source == 'ipahealthcheck.ipa.dns'
+            assert result.check == 'IPADNSSystemRecordsCheck'
+
+    @patch('ipapython.dnsutil.query_srv')
+    @patch('dns.resolver.query')
+    def test_dnsrecords_three(self, mock_query, mock_query_srv):
+        """Test three CA masters, all SRV records"""
+        mock_query_srv.side_effect = query_srv([
+            m_api.env.host,
+            'replica.' + m_api.env.domain,
+            'replica2.' + m_api.env.domain
+        ])
+        mock_query.side_effect = fake_query_three
+
+        m_api.Command.server_find.side_effect = [{
+            'result': [
+                {
+                    'cn': [m_api.env.host],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+                {
+                    'cn': ['replica.' + m_api.env.domain],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+                {
+                    'cn': ['replica2.' + m_api.env.domain],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+            ]
+        }]
+
+        framework = object()
+        registry.initialize(framework)
+        f = IPADNSSystemRecordsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 25
+
+        for result in self.results.results:
+            assert result.result == constants.SUCCESS
+            assert result.source == 'ipahealthcheck.ipa.dns'
+            assert result.check == 'IPADNSSystemRecordsCheck'
+
+    @patch('ipapython.dnsutil.query_srv')
+    @patch('dns.resolver.query')
+    def test_dnsrecords_three_mixed(self, mock_query, mock_query_srv):
+        """Test three masters, only one with a CA, all SRV records"""
+        mock_query_srv.side_effect = query_srv([
+            m_api.env.host,
+            'replica.' + m_api.env.domain,
+            'replica2.' + m_api.env.domain
+        ])
+        mock_query.side_effect = fake_query_one
+
+        m_api.Command.server_find.side_effect = [{
+            'result': [
+                {
+                    'cn': [m_api.env.host],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+                {
+                    'cn': ['replica.' + m_api.env.domain],
+                    'enabled_role_servrole': [
+                        'IPA master'
+                    ],
+                },
+                {
+                    'cn': ['replica2.' + m_api.env.domain],
+                    'enabled_role_servrole': [
+                        'IPA master'
+                    ],
+                },
+            ]
+        }]
+
+        framework = object()
+        registry.initialize(framework)
+        f = IPADNSSystemRecordsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 23
+
+        for result in self.results.results:
+            assert result.result == constants.SUCCESS
+            assert result.source == 'ipahealthcheck.ipa.dns'
+
+    @patch('ipapython.dnsutil.query_srv')
+    @patch('dns.resolver.query')
+    def test_dnsrecords_missing_server(self, mock_query, mock_query_srv):
+        """Drop one of the masters from query_srv
+
+           This will simulate missing SRV records and cause a number of
+           warnings to be thrown.
+        """
+        mock_query_srv.side_effect = query_srv([
+            m_api.env.host,
+            'replica.' + m_api.env.domain
+            # replica2 is missing
+        ])
+        mock_query.side_effect = fake_query_three
+
+        m_api.Command.server_find.side_effect = [{
+            'result': [
+                {
+                    'cn': [m_api.env.host],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+                {
+                    'cn': ['replica.' + m_api.env.domain],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+                {
+                    'cn': ['replica2.' + m_api.env.domain],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+            ]
+        }]
+
+        framework = object()
+        registry.initialize(framework)
+        f = IPADNSSystemRecordsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 25
+
+        ok = get_results_by_severity(self.results.results, constants.SUCCESS)
+        warn = get_results_by_severity(self.results.results, constants.WARNING)
+        assert len(ok) == 18
+        assert len(warn) == 7
+
+        for result in warn:
+            assert result.kw.get('msg') == 'Expected SRV record missing'
+
+    @patch('ipapython.dnsutil.query_srv')
+    @patch('dns.resolver.query')
+    def test_dnsrecords_missing_ipa_ca(self, mock_query, mock_query_srv):
+        """Drop one of the masters from query_srv
+
+           This will simulate missing SRV records and cause a number of
+           warnings to be thrown.
+        """
+        mock_query_srv.side_effect = query_srv([
+            m_api.env.host,
+            'replica.' + m_api.env.domain,
+            'replica2.' + m_api.env.domain
+        ])
+        mock_query.side_effect = fake_query_two
+
+        m_api.Command.server_find.side_effect = [{
+            'result': [
+                {
+                    'cn': [m_api.env.host],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+                {
+                    'cn': ['replica.' + m_api.env.domain],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+                {
+                    'cn': ['replica2.' + m_api.env.domain],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+            ]
+        }]
+
+        framework = object()
+        registry.initialize(framework)
+        f = IPADNSSystemRecordsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 25
+
+        ok = get_results_by_severity(self.results.results, constants.SUCCESS)
+        warn = get_results_by_severity(self.results.results, constants.WARNING)
+        assert len(ok) == 24
+        assert len(warn) == 1
+
+        for result in warn:
+            assert result.kw.get('msg') == \
+                'Got {count} ipa-ca A records, expected {expected}'
+            assert result.kw.get('count') == 2
+            assert result.kw.get('expected') == 3
+
+    @patch('ipapython.dnsutil.query_srv')
+    @patch('dns.resolver.query')
+    def test_dnsrecords_extra_srv(self, mock_query, mock_query_srv):
+        """An extra SRV record set exists, report it.
+
+           Add an extra master to the query_srv() which will generate
+           a full extra set of SRV records for the master.
+        """
+        mock_query_srv.side_effect = query_srv([
+            m_api.env.host,
+            'replica.' + m_api.env.domain,
+            'replica2.' + m_api.env.domain,
+            'replica3.' + m_api.env.domain
+        ])
+        mock_query.side_effect = fake_query_three
+
+        m_api.Command.server_find.side_effect = [{
+            'result': [
+                {
+                    'cn': [m_api.env.host],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+                {
+                    'cn': ['replica.' + m_api.env.domain],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+                {
+                    'cn': ['replica2.' + m_api.env.domain],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+            ]
+        }]
+
+        framework = object()
+        registry.initialize(framework)
+        f = IPADNSSystemRecordsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 32
+
+        ok = get_results_by_severity(self.results.results, constants.SUCCESS)
+        warn = get_results_by_severity(self.results.results, constants.WARNING)
+        assert len(ok) == 25
+        assert len(warn) == 7
+
+        for result in warn:
+            assert result.kw.get('msg') == \
+                'Unexpected SRV entry in DNS'
+
+    @patch('ipapython.dnsutil.query_srv')
+    @patch('dns.resolver.query')
+    def test_dnsrecords_bad_realm(self, mock_query, mock_query_srv):
+        """Unexpected Kerberos TXT record"""
+        mock_query.side_effect = fake_query_one_txt
+        mock_query_srv.side_effect = query_srv([m_api.env.host])
+
+        m_api.Command.server_find.side_effect = [{
+            'result': [
+                {
+                    'cn': [m_api.env.host],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master'
+                    ],
+                },
+            ]
+        }]
+        framework = object()
+        registry.initialize(framework)
+        f = IPADNSSystemRecordsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 9
+
+        ok = get_results_by_severity(self.results.results, constants.SUCCESS)
+        warn = get_results_by_severity(self.results.results, constants.WARNING)
+        assert len(ok) == 8
+        assert len(warn) == 1
+
+        result = warn[0]
+        assert result.kw.get('msg') == 'expected realm missing'
+        assert result.kw.get('key') == '\"FAKE_REALM\"'
+
+    @patch('ipapython.dnsutil.query_srv')
+    @patch('dns.resolver.query')
+    def test_dnsrecords_one_with_ad(self, mock_query, mock_query_srv):
+        mock_query.side_effect = fake_query_one
+        mock_query_srv.side_effect = query_srv([m_api.env.host], True)
+
+        m_api.Command.server_find.side_effect = [{
+            'result': [
+                {
+                    'cn': [m_api.env.host],
+                    'enabled_role_servrole': [
+                        'CA server',
+                        'IPA master',
+                        'AD trust controller'
+                    ],
+                },
+            ]
+        }]
+        framework = object()
+        registry.initialize(framework)
+        f = IPADNSSystemRecordsCheck(registry)
+
+        f.config = config.Config()
+        self.results = capture_results(f)
+
+        assert len(self.results) == 15
+
+        for result in self.results.results:
+            assert result.result == constants.SUCCESS
+            assert result.source == 'ipahealthcheck.ipa.dns'
+            assert result.check == 'IPADNSSystemRecordsCheck'


### PR DESCRIPTION
IPA can provide the expected list of SRV records based on its
configuration (using the IPASystemRecords class) via

ipa dns-update-system-records --dry-run

Take the equivalent of that output and compare it to what is in
DNS.