### PR TITLE
Use correct section name and fix description in ipahealthcheck.conf(5)

### DIFF
--- a/man/man5/ipahealthcheck.conf.5
+++ b/man/man5/ipahealthcheck.conf.5
@@ -28,14 +28,14 @@ Values should not be quoted, the quotes will not be stripped.
     verbose=True
 .DE
 
-Options must appear in the section named [global]. There are no other sections defined or used currently.
+Options must appear in the section named [default]. There are no other sections defined or used currently.
 
 Options may be defined that are not used. Be careful of misspellings, they will not be rejected.
 .SH "OPTIONS"
 The following options are relevant for the server:
 .TP
-.B cert_expiration_days\fR 28
-The number of days left before a certificate expires to start displaying a warning.
+.B cert_expiration_days\fR
+The number of days left before a certificate expires to start displaying a warning. The default is 28.
 .SH "FILES"
 .TP
 .I /etc/ipahealthcheck/ipahealthcheck.conf


### PR DESCRIPTION
The wrong section name, global, was mentioned instead of default.

The 28 after cert_expiration_days made it look like that is how
the value should be listed into the configuration. Move the 28
to the description as the default value.

https://github.com/freeipa/freeipa-healthcheck/issues/88