### PR TITLE
Add an additional test on POSIX permissions

### DIFF
--- a/src/ipahealthcheck/core/files.py
+++ b/src/ipahealthcheck/core/files.py
@@ -27,11 +27,18 @@ class FileCheck:
             fmode = str(oct(stat.st_mode)[-4:])
             key = '%s_mode' % path.replace('/', '_')
             if mode != fmode:
-                yield Result(self, constants.WARNING, key=key,
-                             path=path, type='mode', expected=mode,
-                             got=fmode,
-                             msg='Permissions of %s are %s and '
-                             'should be %s' % (path, fmode, mode))
+                if mode < fmode:
+                    yield Result(self, constants.WARNING, key=key,
+                                 path=path, type='mode', expected=mode,
+                                 got=fmode,
+                                 msg='Permissions of %s are too permissive: '
+                                 '%s and should be %s' % (path, fmode, mode))
+                if mode > fmode:
+                    yield Result(self, constants.ERROR, key=key,
+                                 path=path, type='mode', expected=mode,
+                                 got=fmode,
+                                 msg='Permissions of %s are too restrictive: '
+                                 '%s and should be %s' % (path, fmode, mode))
             else:
                 yield Result(self, constants.SUCCESS, key=key,
                              type='mode', path=path)

--- a/tests/test_core_files.py
+++ b/tests/test_core_files.py
@@ -92,10 +92,16 @@ def test_files_mode(mock_stat):
 
     my_results = get_results(results, 'mode')
     assert my_results.results[0].result == constants.SUCCESS
-    assert my_results.results[1].result == constants.WARNING
+    assert my_results.results[1].result == constants.ERROR
 
-    mock_stat.return_value = make_stat(mode=33204)
+    mock_stat.return_value = make_stat(mode=33152)
+    results = capture_results(f)
+    my_results = get_results(results, 'mode')
+    assert my_results.results[0].result == constants.ERROR
+    assert my_results.results[1].result == constants.ERROR
+
+    mock_stat.return_value = make_stat(mode=33206)
     results = capture_results(f)
     my_results = get_results(results, 'mode')
     assert my_results.results[0].result == constants.WARNING
-    assert my_results.results[1].result == constants.SUCCESS
+    assert my_results.results[1].result == constants.WARNING


### PR DESCRIPTION
As per #58:

Currently healthcheck only logs a warning if a file's permissions are
not equal to the expected perms. It should be WARNING if a file's
permissions are more permissive and an ERROR if they are less permissive
than expected.