### PR TITLE
Add additional test for container detection

### DIFF
--- a/src/ipahealthcheck/system/filesystemspace.py
+++ b/src/ipahealthcheck/system/filesystemspace.py
@@ -13,10 +13,14 @@ from ipahealthcheck.core import constants
 def in_container():
     """Determine if we're running in a container."""
     with open('/proc/1/sched', 'r') as sched:
-        data = sched.readline()
+        data_sched = sched.readline()
+
+    with open('/proc/self/cgroup', 'r') as cgroup:
+        data_cgroup = cgroup.readline()
 
     checks = [
-        data.split()[0] not in ('systemd', 'init',),
+        data_sched.split()[0] not in ('systemd', 'init',),
+        data_cgroup.split()[0] not in ('libpod'),
         os.path.exists('/.dockerenv'),
         os.path.exists('/.dockerinit'),
         os.getenv('container', None) is not None


### PR DESCRIPTION
When running from an ubi8-init image with podman, the existing tests
implemented in 8c75bdf5 will not detect the container. Add a new test
checking for `libpod` in `/proc/self/cgroup`

Example:

```bash
$ podman run --name ubi8-init -d registry.access.redhat.com/ubi8-init

$ podman exec ubi8-init cat /proc/1/sched | head -1
systemd (1, #threads: 1)

$ podman exec ubi8-init cat /proc/self/cgroup
i0::/user.slice/user-1001.slice/user@1001.service/user.slice/libpod-c08663d4addf4722bbc8d708f5a2a131e565d933d23594fd2b22f98e7d72cc45.scope/crun-exec
```

Reference: #75