### PR TITLE
Clarifies the predefined keys of the kw argument of the Result class

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,18 @@ A basic check module consists of:
 A check yields a Result. This contains the outcome of the check including:
 
 * result as defined in ipahealthcheck/core/constants.py
-* msg containing a message to be displayed to the user.
 * kw, a python dictionary of name value pairs that provide details on the error
 
 The kw dict is meant to provide context for the check. Err on the side of
 too much information.
 
-msg and kw are optional if result is SUCCESS.
+Some predefined keys of the kw dictionary are:
+
+* key: some checks can have multiple tests. This provides for uniqueuess.
+* msg: A message that can take other keywords as input
+* exception: used when a check raises an exception
+
+kw is optional if result is SUCCESS.
 
 If a check consist of only a single test then it is not required to yield
 a Result, one marking the check as successful will be added automatically.


### PR DESCRIPTION
Rewording of the README.md to reflect the code in core/plugin.py Result class with regards to the way to pass the predefined keys of  `kw` in the constructor.