### PR TITLE
Patch to allow plugins to read config dict

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -64,7 +64,7 @@ def source_or_check_matches(plugin, source, check):
     return True
 
 
-def run_service_plugins(plugins, config, source, check):
+def run_service_plugins(plugins, source, check):
     """Execute plugins with the base class of ServiceCheck
 
        This is a specialized check to use systemd to determine
@@ -90,7 +90,7 @@ def run_service_plugins(plugins, config, source, check):
     return results, set(available)
 
 
-def run_plugins(plugins, config, available, source, check):
+def run_plugins(plugins, available, source, check):
     """Execute plugins without the base class of ServiceCheck
 
        These are the remaining, non-service checking checks
@@ -106,7 +106,6 @@ def run_plugins(plugins, config, available, source, check):
             continue
 
         logger.debug('Calling check %s' % plugin)
-        plugin.config = config
         if not set(plugin.requires).issubset(available):
             logger.debug('Skipping %s:%s because %s service(s) not running',
                          plugin.__class__.__module__,
@@ -218,7 +217,7 @@ class RunChecks:
 
         for name, registry in find_registries(self.entry_points).items():
             try:
-                registry.initialize(framework)
+                registry.initialize(framework, config)
             except Exception as e:
                 print("Unable to initialize %s: %s" % (name, e))
                 return 1
@@ -246,10 +245,10 @@ class RunChecks:
             if options.source:
                 results = limit_results(results, options.source, options.check)
         else:
-            results, available = run_service_plugins(plugins, config,
+            results, available = run_service_plugins(plugins,
                                                      options.source,
                                                      options.check)
-            results.extend(run_plugins(plugins, config, available,
+            results.extend(run_plugins(plugins, available,
                                        options.source, options.check))
 
         if options.source and len(results.results) == 0:

--- a/src/ipahealthcheck/core/plugin.py
+++ b/src/ipahealthcheck/core/plugin.py
@@ -41,9 +41,11 @@ class Registry:
     def __init__(self):
         self.plugins = []
         self.framework = None
+        self.config = dict()
 
-    def initialize(self, framework):
+    def initialize(self, framework, config):
         self.framework = framework
+        self.config = config
 
     def __call__(self, cls):
         if not callable(cls):
@@ -98,7 +100,7 @@ class Plugin:
 
     def __init__(self, registry):
         self.registry = registry
-        self.config = dict()
+        self.config = registry.config
 
 
 class Result:

--- a/src/ipahealthcheck/dogtag/plugin.py
+++ b/src/ipahealthcheck/dogtag/plugin.py
@@ -16,7 +16,8 @@ class DogtagPlugin(Plugin):
 
 
 class DogtagRegistry(Registry):
-    def initialize(self, framework):
+    def initialize(self, framework, config):
+        super(DogtagRegistry, self).initialize(framework, config)
         installutils.check_server_configuration()
         if not api.isdone('bootstrap'):
             api.bootstrap(in_server=True,

--- a/src/ipahealthcheck/ds/plugin.py
+++ b/src/ipahealthcheck/ds/plugin.py
@@ -16,7 +16,8 @@ class DSPlugin(Plugin):
 
 
 class DSRegistry(Registry):
-    def initialize(self, framework):
+    def initialize(self, framework, config):
+        super(DSRegistry, self).initialize(framework, config)
         installutils.check_server_configuration()
         if not api.isdone('bootstrap'):
             api.bootstrap(in_server=True,

--- a/src/ipahealthcheck/ipa/plugin.py
+++ b/src/ipahealthcheck/ipa/plugin.py
@@ -36,7 +36,8 @@ class IPARegistry(Registry):
         self.trust_agent = False
         self.trust_controller = False
 
-    def initialize(self, framework):
+    def initialize(self, framework, config):
+        super(IPARegistry, self).initialize(framework, config)
         # deferred import for mock
         from ipaserver.servroles import ADtrustBasedRole, ServiceBasedRole
 

--- a/src/ipahealthcheck/system/plugin.py
+++ b/src/ipahealthcheck/system/plugin.py
@@ -12,7 +12,7 @@ class SystemPlugin(Plugin):
 
 
 class SystemRegistry(Registry):
-    def initialize(self, framework):
+    def initialize(self, framework, config):
         pass
 
 

--- a/tests/test_dogtag_ca.py
+++ b/tests/test_dogtag_ca.py
@@ -59,10 +59,9 @@ class TestCACerts(BaseTest):
         mock_directive.side_effect = [name for name, nsstrust in trust.items()]
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config())
         f = DogtagCertsConfigCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 6
@@ -98,10 +97,9 @@ class TestCACerts(BaseTest):
         mock_directive.side_effect = nicknames
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = DogtagCertsConfigCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         num = len(self.results.results)
@@ -129,10 +127,9 @@ class TestCACerts(BaseTest):
         mock_cainstance.return_value = CAInstance(False)
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config)
         f = DogtagCertsConfigCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 0

--- a/tests/test_dogtag_connectivity.py
+++ b/tests/test_dogtag_connectivity.py
@@ -5,7 +5,7 @@
 from util import capture_results, CAInstance
 from util import m_api
 from base import BaseTest
-from ipahealthcheck.core import constants
+from ipahealthcheck.core import constants, config
 from ipahealthcheck.dogtag.plugin import registry
 from ipahealthcheck.dogtag.ca import DogtagCertsConnectivityCheck
 from unittest.mock import Mock
@@ -26,7 +26,7 @@ class TestCAConnectivity(BaseTest):
         }
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = DogtagCertsConnectivityCheck(registry)
 
         self.results = capture_results(f)
@@ -47,7 +47,7 @@ class TestCAConnectivity(BaseTest):
         )
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = DogtagCertsConnectivityCheck(registry)
 
         self.results = capture_results(f)
@@ -67,7 +67,7 @@ class TestCAConnectivity(BaseTest):
         )
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = DogtagCertsConnectivityCheck(registry)
 
         self.results = capture_results(f)

--- a/tests/test_ds_replication.py
+++ b/tests/test_ds_replication.py
@@ -44,10 +44,9 @@ class TestReplicationConflicts(BaseTest):
         mock_conn.return_value = mock_ldap(None)
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = ReplicationConflictCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         # A valid call relies on a success to be set by core
@@ -73,10 +72,9 @@ class TestReplicationConflicts(BaseTest):
         mock_conn.return_value = mock_ldap([ldapentry])
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = ReplicationConflictCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
         result = self.results.results[0]
 

--- a/tests/test_ds_ruv.py
+++ b/tests/test_ds_ruv.py
@@ -63,11 +63,10 @@ class TestRUV(BaseTest):
 
     def test_no_ruvs(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = RUVCheck(registry)
 
         f.conn = mock_ldap(None)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 0
@@ -88,11 +87,10 @@ class TestRUV(BaseTest):
         )
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = RUVCheck(registry)
 
         f.conn = mock_ldap(entries)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -123,11 +121,10 @@ class TestRUV(BaseTest):
         entries.append(None)
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = RUVCheck(registry)
 
         f.conn = mock_ldap(entries)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1

--- a/tests/test_ipa_agent.py
+++ b/tests/test_ipa_agent.py
@@ -76,11 +76,10 @@ class TestNSSAgent(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config())
         f = IPARAAgent(registry)
 
         f.conn = mock_ldap([ldapentry])
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -101,11 +100,10 @@ class TestNSSAgent(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config())
         f = IPARAAgent(registry)
 
         f.conn = mock_ldap([ldapentry])
-        f.config = config.Config()
         self.results = capture_results(f)
         result = self.results.results[0]
 
@@ -118,10 +116,9 @@ class TestNSSAgent(BaseTest):
         mock_load_cert.side_effect = IOError('test')
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config())
         f = IPARAAgent(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
         result = self.results.results[0]
 
@@ -131,11 +128,10 @@ class TestNSSAgent(BaseTest):
     def test_nss_agent_no_entry_found(self):
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config())
         f = IPARAAgent(registry)
 
         f.conn = mock_ldap(None)  # None == NotFound
-        f.config = config.Config()
         self.results = capture_results(f)
         result = self.results.results[0]
 
@@ -158,11 +154,10 @@ class TestNSSAgent(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config())
         f = IPARAAgent(registry)
 
         f.conn = mock_ldap([ldapentry, ldapentry2])
-        f.config = config.Config()
         self.results = capture_results(f)
         result = self.results.results[0]
 
@@ -183,11 +178,10 @@ class TestNSSAgent(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config())
         f = IPARAAgent(registry)
 
         f.conn = mock_ldap([ldapentry])
-        f.config = config.Config()
         self.results = capture_results(f)
         result = self.results.results[0]
 
@@ -208,11 +202,10 @@ class TestNSSAgent(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPARAAgent(registry)
 
         f.conn = mock_ldap([ldapentry])
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1

--- a/tests/test_ipa_certfile_expiration.py
+++ b/tests/test_ipa_certfile_expiration.py
@@ -41,10 +41,9 @@ class TestIPACertificateFile(BaseTest):
         mock_load_cert.return_value = cert
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertfileExpirationCheck(registry)
 
-        f.config = config.Config()
         f.config.cert_expiration_days = 28
         self.results = capture_results(f)
 
@@ -65,10 +64,9 @@ class TestIPACertificateFile(BaseTest):
         mock_load_cert.return_value = cert
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertfileExpirationCheck(registry)
 
-        f.config = config.Config()
         f.config.cert_expiration_days = 30
         self.results = capture_results(f)
 
@@ -90,10 +88,9 @@ class TestIPACertificateFile(BaseTest):
         mock_load_cert.return_value = cert
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertfileExpirationCheck(registry)
 
-        f.config = config.Config()
         f.config.cert_expiration_days = 30
         self.results = capture_results(f)
 

--- a/tests/test_ipa_certmonger_ca.py
+++ b/tests/test_ipa_certmonger_ca.py
@@ -4,7 +4,7 @@
 
 from util import capture_results, CAInstance
 from base import BaseTest
-from ipahealthcheck.core import constants
+from ipahealthcheck.core import constants, config
 from ipahealthcheck.ipa.plugin import registry
 from ipahealthcheck.ipa.certs import IPACertmongerCA
 from unittest.mock import Mock, patch
@@ -24,7 +24,7 @@ class TestCertmonger(BaseTest):
             'dogtag-ipa-ca-renew-agent-reuse'
         ]
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertmongerCA(registry)
 
         self.results = capture_results(f)
@@ -44,7 +44,7 @@ class TestCertmonger(BaseTest):
         ]
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertmongerCA(registry)
 
         self.results = capture_results(f)

--- a/tests/test_ipa_dna.py
+++ b/tests/test_ipa_dna.py
@@ -31,10 +31,9 @@ class TestDNARange(BaseTest):
     def test_dnarange_set(self, mock_manager):
         mock_manager.return_value = mock_ReplicationManager(start=1, max=100)
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPADNARangeCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -52,10 +51,9 @@ class TestDNARange(BaseTest):
     def test_dnarange_noset(self, mock_manager):
         mock_manager.return_value = mock_ReplicationManager()
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPADNARangeCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -76,10 +74,9 @@ class TestDNARange(BaseTest):
                                                             next=101,
                                                             next_max=200)
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPADNARangeCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1

--- a/tests/test_ipa_dns.py
+++ b/tests/test_ipa_dns.py
@@ -192,10 +192,9 @@ class TestDNSSystemRecords(BaseTest):
             ]
         }]
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPADNSSystemRecordsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 9
@@ -235,10 +234,9 @@ class TestDNSSystemRecords(BaseTest):
         }]
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPADNSSystemRecordsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 17
@@ -286,10 +284,9 @@ class TestDNSSystemRecords(BaseTest):
         }]
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPADNSSystemRecordsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 25
@@ -335,10 +332,9 @@ class TestDNSSystemRecords(BaseTest):
         }]
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPADNSSystemRecordsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 23
@@ -389,10 +385,9 @@ class TestDNSSystemRecords(BaseTest):
         }]
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPADNSSystemRecordsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 25
@@ -447,10 +442,9 @@ class TestDNSSystemRecords(BaseTest):
         }]
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPADNSSystemRecordsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 25
@@ -509,10 +503,9 @@ class TestDNSSystemRecords(BaseTest):
         }]
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPADNSSystemRecordsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 32
@@ -545,10 +538,9 @@ class TestDNSSystemRecords(BaseTest):
             ]
         }]
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPADNSSystemRecordsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 9
@@ -581,10 +573,9 @@ class TestDNSSystemRecords(BaseTest):
             ]
         }]
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPADNSSystemRecordsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 15

--- a/tests/test_ipa_expiration.py
+++ b/tests/test_ipa_expiration.py
@@ -30,10 +30,9 @@ class TestExpiration(BaseTest):
         set_requests()
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertmongerExpirationCheck(registry)
 
-        f.config = config.Config()
         f.config.cert_expiration_days = 7
         self.results = capture_results(f)
 
@@ -66,10 +65,9 @@ class TestExpiration(BaseTest):
         set_requests(remove=0, add=replaceme)
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertmongerExpirationCheck(registry)
 
-        f.config = config.Config()
         f.config.cert_expiration_days = 30
         self.results = capture_results(f)
 
@@ -122,10 +120,9 @@ class TestChainExpiration(BaseTest):
             )
         ]
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACAChainExpirationCheck(registry)
 
-        f.config = config.Config()
         f.config.cert_expiration_days = 7
         self.results = capture_results(f)
 
@@ -160,10 +157,9 @@ class TestChainExpiration(BaseTest):
             )
         ]
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACAChainExpirationCheck(registry)
 
-        f.config = config.Config()
         f.config.cert_expiration_days = 7
         self.results = capture_results(f)
 
@@ -200,10 +196,9 @@ class TestChainExpiration(BaseTest):
             )
         ]
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACAChainExpirationCheck(registry)
 
-        f.config = config.Config()
         f.config.cert_expiration_days = 7
         self.results = capture_results(f)
 
@@ -238,10 +233,9 @@ class TestChainExpiration(BaseTest):
             )
         ]
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACAChainExpirationCheck(registry)
 
-        f.config = config.Config()
         f.config.cert_expiration_days = 7
         self.results = capture_results(f)
 

--- a/tests/test_ipa_nssdb.py
+++ b/tests/test_ipa_nssdb.py
@@ -48,10 +48,9 @@ class TestNSSDBTrust(BaseTest):
         mock_certdb.return_value = mock_CertDB(trust)
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertNSSTrust(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 4
@@ -74,10 +73,9 @@ class TestNSSDBTrust(BaseTest):
         mock_certdb.return_value = mock_CertDB(trust)
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertNSSTrust(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         # The check reports success for those that it found and are correct and
@@ -114,10 +112,9 @@ class TestNSSDBTrust(BaseTest):
         mock_certdb.return_value = mock_CertDB(trust)
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertNSSTrust(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         result = self.results.results[1]
@@ -149,10 +146,9 @@ class TestNSSDBTrust(BaseTest):
         mock_cainstance.return_value = CAInstance(False)
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertNSSTrust(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 0

--- a/tests/test_ipa_nssvalidation.py
+++ b/tests/test_ipa_nssvalidation.py
@@ -38,10 +38,9 @@ class TestNSSValidation(BaseTest):
         mock_cainstance.return_value = CAInstance()
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPANSSChainValidation(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -68,10 +67,9 @@ class TestNSSValidation(BaseTest):
         mock_cainstance.return_value = CAInstance()
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPANSSChainValidation(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -97,10 +95,9 @@ class TestNSSValidation(BaseTest):
         mock_cainstance.return_value = CAInstance(False)
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPANSSChainValidation(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1

--- a/tests/test_ipa_opensslvalidation.py
+++ b/tests/test_ipa_opensslvalidation.py
@@ -30,10 +30,9 @@ class TestOpenSSLValidation(BaseTest):
         mock_run.side_effect = run
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPAOpenSSLChainValidation(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -59,10 +58,9 @@ class TestOpenSSLValidation(BaseTest):
         mock_run.side_effect = run
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPAOpenSSLChainValidation(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 2

--- a/tests/test_ipa_revocation.py
+++ b/tests/test_ipa_revocation.py
@@ -54,10 +54,9 @@ class TestRevocation(BaseTest):
         set_requests()
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertRevocation(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -84,10 +83,9 @@ class TestRevocation(BaseTest):
         set_requests()
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertRevocation(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 2

--- a/tests/test_ipa_roles.py
+++ b/tests/test_ipa_roles.py
@@ -18,10 +18,9 @@ class TestCRLManagerRole(BaseTest):
     def test_not_crlmanager(self, mock_ca):
         mock_ca.return_value = CAInstance(crlgen=False)
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACRLManagerCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -36,10 +35,9 @@ class TestCRLManagerRole(BaseTest):
     def test_crlmanager(self, mock_ca):
         mock_ca.return_value = CAInstance()
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACRLManagerCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -54,7 +52,7 @@ class TestCRLManagerRole(BaseTest):
 class TestRenewalMaster(BaseTest):
     def test_renewal_master_not_set(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPARenewalMasterCheck(registry)
 
         m_api.Command.config_show.side_effect = [{
@@ -62,7 +60,6 @@ class TestRenewalMaster(BaseTest):
             }
         }]
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -75,7 +72,7 @@ class TestRenewalMaster(BaseTest):
 
     def test_not_renewal_master(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPARenewalMasterCheck(registry)
 
         m_api.Command.config_show.side_effect = [{
@@ -84,7 +81,6 @@ class TestRenewalMaster(BaseTest):
             }
         }]
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -97,7 +93,7 @@ class TestRenewalMaster(BaseTest):
 
     def test_is_renewal_master(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPARenewalMasterCheck(registry)
 
         m_api.Command.config_show.side_effect = [{
@@ -106,7 +102,6 @@ class TestRenewalMaster(BaseTest):
             }
         }]
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1

--- a/tests/test_ipa_topology.py
+++ b/tests/test_ipa_topology.py
@@ -28,10 +28,9 @@ class TestTopology(BaseTest):
         m_api.Command.ca_is_enabled.return_value = {'result': True}
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPATopologyDomainCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -71,10 +70,9 @@ class TestTopology(BaseTest):
         m_api.Command.ca_is_enabled.return_value = {'result': True}
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPATopologyDomainCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 3
@@ -135,10 +133,9 @@ class TestTopology(BaseTest):
         m_api.Command.ca_is_enabled.return_value = {'result': True}
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPATopologyDomainCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 3
@@ -193,10 +190,9 @@ class TestTopology(BaseTest):
         m_api.Command.ca_is_enabled.return_value = {'result': True}
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPATopologyDomainCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 2

--- a/tests/test_ipa_tracking.py
+++ b/tests/test_ipa_tracking.py
@@ -5,7 +5,7 @@
 from util import capture_results
 from base import BaseTest
 
-from ipahealthcheck.core import constants
+from ipahealthcheck.core import constants, config
 from ipahealthcheck.ipa.plugin import registry
 from ipahealthcheck.ipa.certs import IPACertTracking
 from unittest.mock import Mock
@@ -27,7 +27,7 @@ class TestTracking(BaseTest):
         set_requests()
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertTracking(registry)
 
         self.results = capture_results(f)
@@ -39,7 +39,7 @@ class TestTracking(BaseTest):
         set_requests(remove=0)
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertTracking(registry)
 
         self.results = capture_results(f)
@@ -71,7 +71,7 @@ class TestTracking(BaseTest):
         set_requests(add=unknown)
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = IPACertTracking(registry)
 
         self.results = capture_results(f)

--- a/tests/test_ipa_trust.py
+++ b/tests/test_ipa_trust.py
@@ -109,11 +109,10 @@ class SSSDConfig():
 class TestTrustAgent(BaseTest):
     def test_no_trust_agent(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = False
         f = IPATrustAgentCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         # Zero because the call was skipped altogether
@@ -124,11 +123,10 @@ class TestTrustAgent(BaseTest):
         mock_sssd.return_value = SSSDConfig(return_domains=True,
                                             return_ipa_server_mode=True)
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPATrustAgentCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -143,11 +141,10 @@ class TestTrustAgent(BaseTest):
         mock_sssd.return_value = SSSDConfig(return_domains=True,
                                             return_ipa_server_mode=False)
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPATrustAgentCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -164,11 +161,10 @@ class TestTrustAgent(BaseTest):
         mock_sssd.return_value = SSSDConfig(return_domains=True,
                                             return_ipa_server_mode=None)
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPATrustAgentCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -184,11 +180,10 @@ class TestTrustAgent(BaseTest):
 class TestTrustDomains(BaseTest):
     def test_no_trust_agent(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = False
         f = IPATrustDomainsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         # Zero because the call was skipped altogether
@@ -202,11 +197,10 @@ class TestTrustDomains(BaseTest):
         mock_run.return_value = run_result
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPATrustDomainsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -230,11 +224,10 @@ class TestTrustDomains(BaseTest):
         mock_trust.side_effect = errors.NotFound(reason='bad')
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPATrustDomainsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         # There are more than one result I just care about this particular
@@ -279,11 +272,10 @@ class TestTrustDomains(BaseTest):
         }]
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPATrustDomainsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 3
@@ -344,11 +336,10 @@ class TestTrustDomains(BaseTest):
         }]
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPATrustDomainsCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -374,12 +365,11 @@ class TestIPADomain(BaseTest):
     def test_ipa_domain_ok(self, mock_sssd):
         mock_sssd.return_value = SSSDConfig(provider='ipa')
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         # being a trust agent isn't mandatory, test without
         registry.trust_agent = False
         f = IPADomainCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         print(self.results.results)
@@ -394,11 +384,10 @@ class TestIPADomain(BaseTest):
     def test_ipa_domain_ad(self, mock_sssd):
         mock_sssd.return_value = SSSDConfig(provider='ad')
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPADomainCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 4
@@ -413,11 +402,10 @@ class TestIPADomain(BaseTest):
 class TestTrustCatalog(BaseTest):
     def test_no_trust_agent(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = False
         f = IPATrustCatalogCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         # Zero because the call was skipped altogether
@@ -464,11 +452,10 @@ class TestTrustCatalog(BaseTest):
         }]
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPATrustCatalogCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 6
@@ -524,11 +511,10 @@ class Testsidgen(BaseTest):
 
     def test_no_trust_agent(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = False
         f = IPAsidgenpluginCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         # Zero because the call was skipped altogether
@@ -544,12 +530,11 @@ class Testsidgen(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPAsidgenpluginCheck(registry)
 
         f.conn = mock_ldap(ldapentry)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -576,12 +561,11 @@ class Testsidgen(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPAsidgenpluginCheck(registry)
 
         f.conn = mock_ldap(ldapentry)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -607,11 +591,10 @@ class TestTrustAgentMember(BaseTest):
 
     def test_no_trust_agent(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = False
         f = IPATrustAgentMemberCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         # Zero because the call was skipped altogether
@@ -632,12 +615,11 @@ class TestTrustAgentMember(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPATrustAgentMemberCheck(registry)
 
         f.conn = mock_ldap(ldapentry)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -660,12 +642,11 @@ class TestTrustAgentMember(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_agent = True
         f = IPATrustAgentMemberCheck(registry)
 
         f.conn = mock_ldap(ldapentry)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -685,11 +666,10 @@ class TestControllerPrincipal(BaseTest):
 
     def test_not_trust_controller(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = False
         f = IPATrustControllerPrincipalCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         # Zero because the call was skipped altogether
@@ -711,12 +691,11 @@ class TestControllerPrincipal(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = True
         f = IPATrustControllerPrincipalCheck(registry)
 
         f.conn = mock_ldap(ldapentry)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -740,12 +719,11 @@ class TestControllerPrincipal(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = True
         f = IPATrustControllerPrincipalCheck(registry)
 
         f.conn = mock_ldap(ldapentry)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -765,11 +743,10 @@ class TestControllerService(BaseTest):
 
     def test_not_trust_controller(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = False
         f = IPATrustControllerServiceCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         # Zero because the call was skipped altogether
@@ -786,12 +763,11 @@ class TestControllerService(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = True
         f = IPATrustControllerServiceCheck(registry)
 
         f.conn = mock_ldap(ldapentry)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -813,12 +789,11 @@ class TestControllerService(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = True
         f = IPATrustControllerServiceCheck(registry)
 
         f.conn = mock_ldap(ldapentry)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -837,11 +812,10 @@ class TestControllerGroupSID(BaseTest):
 
     def test_not_trust_controller(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = False
         f = IPATrustControllerGroupSIDCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         # Zero because the call was skipped altogether
@@ -859,12 +833,11 @@ class TestControllerGroupSID(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = True
         f = IPATrustControllerGroupSIDCheck(registry)
 
         f.conn = mock_ldap(ldapentry)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -888,12 +861,11 @@ class TestControllerGroupSID(BaseTest):
             ldapentry[attr] = values
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = True
         f = IPATrustControllerGroupSIDCheck(registry)
 
         f.conn = mock_ldap(ldapentry)
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -914,11 +886,10 @@ class TestControllerConf(BaseTest):
 
     def test_not_trust_controller(self):
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = False
         f = IPATrustControllerConfCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         # Zero because the call was skipped altogether
@@ -934,11 +905,10 @@ class TestControllerConf(BaseTest):
         mock_run.return_value = run_result
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = True
         f = IPATrustControllerConfCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -954,11 +924,10 @@ class TestPackageCheck(BaseTest):
     def test_agent_with_package(self):
         # Note that this test assumes the import is installed
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = False
         registry.trust_agent = True
         f = IPATrustPackageCheck(registry)
-        f.config = config.Config()
         self.results = capture_results(f)
         assert len(self.results) == 1
         result = self.results.results[0]
@@ -969,14 +938,13 @@ class TestPackageCheck(BaseTest):
     def test_agent_without_package(self):
         # Note that this test assumes the import is installed
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         registry.trust_controller = False
         registry.trust_agent = True
         # Hose up the module so the import fails
         save = sys.modules['ipaserver.install']
         sys.modules['ipaserver.install'] = 'foo'
         f = IPATrustPackageCheck(registry)
-        f.config = config.Config()
         self.results = capture_results(f)
         assert len(self.results) == 1
         result = self.results.results[0]

--- a/tests/test_meta_services.py
+++ b/tests/test_meta_services.py
@@ -7,6 +7,7 @@ from base import BaseTest
 
 from ipahealthcheck.ipa.plugin import registry
 from ipahealthcheck.meta.services import httpd
+from ipahealthcheck.core import config
 
 
 class TestServices(BaseTest):
@@ -19,7 +20,7 @@ class TestServices(BaseTest):
         running.
         """
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = httpd(registry)
 
         self.results = capture_results(f)

--- a/tests/test_system_filesystemspace.py
+++ b/tests/test_system_filesystemspace.py
@@ -28,10 +28,9 @@ class TestFileSystemNotEnoughFreeSpace(BaseTest):
     def test_filesystem_near_enospc(self):
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = FileSystemSpaceCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         expected_results = 10 if in_container() else 12
@@ -64,10 +63,9 @@ class TestFileSystemNotEnoughFreeSpacePercentage(BaseTest):
     def test_filesystem_risking_fragmentation(self):
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = FileSystemSpaceCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         expected_results = 10 if in_container() else 12
@@ -100,10 +98,9 @@ class TestFileSystemEnoughFreeSpace(BaseTest):
     def test_filesystem_with_enough_space(self):
 
         framework = object()
-        registry.initialize(framework)
+        registry.initialize(framework, config.Config)
         f = FileSystemSpaceCheck(registry)
 
-        f.config = config.Config()
         self.results = capture_results(f)
 
         expected_results = 10 if in_container() else 12


### PR DESCRIPTION
This patch allows the plugins to use the values parsed from the
`healthcheck.conf` file while initializing. This improves the way
a plugin can use the values defined in the conf

Thanks @rcritten for the patch.

**Note:** Currently, the dictionary created is compiled into a **single dictionary**. There is no way to differentiate values from different sections

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`