### PR TITLE
Remove testing of Fedora 29, it is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ cache: pip
 env:
     matrix:
         - TASK_TO_RUN="lint"
-        - TASK_TO_RUN="fedora:29"
         - TASK_TO_RUN="fedora:30"
         - TASK_TO_RUN="fedora:31"
 


### PR DESCRIPTION
It was tested originally because it tested against the IPA 4.7.x
branch.