### PR TITLE
[Minor] Move ipa-healthcheck man category to 8

### DIFF
--- a/man/man5/ipahealthcheck.conf.5
+++ b/man/man5/ipahealthcheck.conf.5
@@ -41,4 +41,4 @@ The number of days left before a certificate expires to start displaying a warni
 .I /etc/ipahealthcheck/ipahealthcheck.conf
 configuration file
 .SH "SEE ALSO"
-.BR ipa-healthcheck (1)
+.BR ipa-healthcheck (8)

--- a/man/man8/ipa-healthcheck.8
+++ b/man/man8/ipa-healthcheck.8
@@ -1,7 +1,7 @@
 .\" A man page for ipa-healthcheck
 .\" Copyright (C) 2019  FreeIPA Contributors see COPYING for license
 .\"
-.TH "ipa-healthcheck" "1" "Apr  4 2019" "FreeIPA" "FreeIPA Manual Pages"
+.TH "ipa-healthcheck" "8" "Jan 16 2020" "FreeIPA" "FreeIPA Manual Pages"
 .SH "NAME"
 ipa\-healthcheck \- Check on the health of an IPA installation
 .SH "SYNOPSIS"


### PR DESCRIPTION
The `ipa-healthcheck` command needs to be executed as a superuser since it
requires special privileges. Category 1 man pages are used for regular
user-commands, while Category 8 is used for superuser commands. Hence,
moving the ipa-healthcheck to the right category.

Ref: https://linux.die.net/man/8/intro

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`