### PR TITLE
Collect the entire list of masters in the meta plugin

### DIFF
--- a/src/ipahealthcheck/meta/core.py
+++ b/src/ipahealthcheck/meta/core.py
@@ -7,13 +7,21 @@ from ipahealthcheck.core import constants
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.meta.plugin import Plugin, registry
 from ipapython.version import VERSION, API_VERSION
+from ipapython.dn import DN
+from ipalib import api
 
 
 @registry
 class MetaCheck(Plugin):
     @duration
     def check(self):
+        conn = api.Backend.ldap2
+        masters_dn = DN(api.env.container_masters, api.env.basedn)
+        masters = conn.get_entries(masters_dn, conn.SCOPE_ONELEVEL)
+        known = [master.single_value['cn'] for master in masters]
+
         yield Result(self, constants.SUCCESS,
                      fqdn=socket.getfqdn(),
+                     masters=known,
                      ipa_version=VERSION,
                      ipa_api_version=API_VERSION,)


### PR DESCRIPTION
This is so the total known masters is known when doing cluster
evaluation. A master may not have provided its healthcheck log
so it will be unknonw to the cluster.