### PR TITLE
Cluster RUV checking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
             'ipadns = ipahealthcheck.ipa.idns',
             'ipafiles = ipahealthcheck.ipa.files',
             'ipahost = ipahealthcheck.ipa.host',
+            'ipameta = ipahealthcheck.ipa.meta',
             'iparoles = ipahealthcheck.ipa.roles',
             'ipatopology = ipahealthcheck.ipa.topology',
             'ipatrust = ipahealthcheck.ipa.trust',

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         ],
         'ipaclustercheck.ipa': [
             'crl = ipaclustercheck.ipa.crlmanager',
+            'ruv = ipaclustercheck.ipa.ruv',
         ],
     },
     classifiers=[

--- a/src/ipaclustercheck/ipa/crlmanager.py
+++ b/src/ipaclustercheck/ipa/crlmanager.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2019 FreeIPA Contributors see COPYING for license
 #
 
-from ipaclustercheck.ipa.plugin import ClusterPlugin, registry, find_check
+from ipaclustercheck.ipa.plugin import ClusterPlugin, registry, find_checks
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.core import constants
 
@@ -16,9 +16,9 @@ class ClusterCRLManagerCheck(ClusterPlugin):
         crlmanagers = []
 
         for fqdn in data.keys():
-             output = find_check(data[fqdn], 'ipahealthcheck.ipa.roles',
+             output = find_checks(data[fqdn], 'ipahealthcheck.ipa.roles',
                                  'IPACRLManagerCheck')
-             enabled = output.get('kw').get('crlgen_enabled')
+             enabled = output[0].get('kw').get('crlgen_enabled')
              if enabled:
                  crlmanagers.append(fqdn)
         if len(crlmanagers) == 0:

--- a/src/ipaclustercheck/ipa/plugin.py
+++ b/src/ipaclustercheck/ipa/plugin.py
@@ -31,6 +31,34 @@ def find_checks(data, source, check):
     return rval
 
 
+def get_masters(data):
+    """
+    Return the list of known masters
+
+    This is determined from the list of loaded healthcheck logs. It
+    is possible that mixed versions are used so some may not be
+    reporting the full list of masters, so check them all, and raise
+    an exception if the list cannot be determined.
+    """
+    test_masters = list(data)
+    masters = None
+    for master in test_masters:
+        output = find_checks(data[master], 'ipahealthcheck.ipa.meta',
+                             'IPAMetaCheck')
+        if len(output) == 0:
+            raise ValueError('Unable to determine full list of masters. '
+                             'ipahealthcheck.ipa.meta:IPAMetaCheck not '
+                             'found.')
+
+        masters = output[0].get('kw').get('masters')
+        if masters:
+            return masters          
+
+    raise ValueError('Unable to determine full list of masters. '
+                     'None of ipahealthcheck.ipa.meta:IPAMetaCheck '
+                     'contain masters.')
+
+
 class ClusterPlugin(Plugin):
     def __init__(self, registry):
         super(ClusterPlugin, self).__init__(registry)

--- a/src/ipaclustercheck/ipa/ruv.py
+++ b/src/ipaclustercheck/ipa/ruv.py
@@ -1,0 +1,141 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+import logging
+
+from ipaclustercheck.ipa.plugin import ClusterPlugin, registry, find_checks
+from ipahealthcheck.core.plugin import Result, duration
+from ipahealthcheck.core import constants
+from ipalib import api
+from ipapython.dn import DN
+
+
+logger = logging.getLogger()
+
+
+@registry
+class ClusterRUVCheck(ClusterPlugin):
+
+    # TODO: confirm that all masters are represented, otherwise the
+    #       trustworthiness of dangling RUV is mixed.
+    #
+    #       gah, need to provide full list of all masters in a check.
+
+    @duration
+    def check(self):
+        data = self.registry.json
+
+        # Start with the list of masters from the file(s) collected
+        # and find a MetaCheck with a full list of masters. For
+        # backwards compatibility.
+        test_masters = list(data)
+        masters = None
+        for master in test_masters:
+            output = find_checks(data[master], 'ipahealthcheck.meta.core',
+                                 'MetaCheck')
+            # TODO: catch if no masters
+            masters = output[0].get('kw').get('masters')
+            if masters:
+                break
+
+        if masters is None:
+            yield Result(self, constants.ERROR,
+                         name='ruv',
+                         error='Full list of masters not found in log files.'
+                               'This should be in ipahealthcheck.meta.core '
+                               'MetaCheck')
+            return
+
+        # collect the full set of known RUVs for each master
+        info = {}
+        for master in masters:
+            info[master] = {
+                'ca': False,           # does the host have ca configured?
+                'ruvs': set(),         # ruvs on the host
+                'csruvs': set(),       # csruvs on the host
+                'clean_ruv': set(),    # ruvs to be cleaned from the host
+                'clean_csruv': set()   # csruvs to be cleaned from the host
+                }
+
+        for fqdn in data.keys():
+            outputs = find_checks(data[fqdn], 'ipahealthcheck.ds.ruv',
+                                  'KnownRUVCheck')
+            for output in outputs:
+                basedn = DN(output.get('kw').get('suffix'))
+
+                ruvset = set()
+                ruvtmp = output.get('kw').get('ruvs')
+                for ruv in ruvtmp:
+                    ruvset.add(tuple(ruv))
+
+                if basedn == DN('o=ipaca'):
+                    info[fqdn]['ca'] = True
+                    info[fqdn]['csruvs'] = ruvset
+                elif basedn == api.env.basedn:
+                    info[fqdn]['ruvs'] = ruvset
+                else:
+                    yield Result(self, constants.WARNING,
+                                 name='ruv',
+                                 error='Unknown suffix found %s' % basedn)
+
+        # Collect the nsDS5ReplicaID for each master
+        ruvs = set()
+        csruvs = set()
+        for fqdn in data.keys():
+            outputs = find_checks(data[fqdn], 'ipahealthcheck.ds.ruv',
+                                  'RUVCheck')
+            for output in outputs:
+                basedn = DN(output.get('kw').get('key'))
+                ruv = (fqdn, (output.get('kw').get('ruv')))
+                if basedn == DN('o=ipaca'):
+                    csruvs.add(ruv)
+                elif basedn == api.env.basedn:
+                    ruvs.add(ruv)
+                else:
+                    yield Result(self, constants.WARNING,
+                                 name='ruv',
+                                 error='Unknown suffix found %s' % basedn)
+
+        dangles = False
+        # get the dangling RUVs
+        for master_info in info.values():
+            for ruv in master_info['ruvs']:
+                if ruv not in ruvs:
+                    master_info['clean_ruv'].add(ruv)
+                    dangles = True
+
+            # if ca is not configured, there will be no csruvs in master_info
+            for csruv in master_info['csruvs']:
+                if csruv not in csruvs:
+                    master_info['clean_csruv'].add(csruv)
+                    dangles = True
+
+        if dangles:
+            clean_csruvs = set()
+            clean_ruvs = set()
+            for master_cn, master_info in info.items():
+                for ruv in master_info['clean_ruv']:
+                    logger.debug('Dangling RUV id: {id}, hostname: {host}'
+                                 .format(id=ruv[1], host=ruv[0]))
+                    clean_ruvs.add(ruv[1])
+                for csruv in master_info['clean_csruv']:
+                    logger.debug('Dangling CS RUV id: {id}, hostname: {host}'
+                                 .format(id=csruv[1], host=csruv[0]))
+                    clean_csruvs.add(csruv[1])
+
+            if clean_ruvs:
+                yield Result(self, constants.ERROR,
+                             name='dangling_ruv',
+                             value=', '.join(clean_ruvs))
+            if clean_csruvs:
+                yield Result(self, constants.ERROR,
+                             name='dangling_csruv',
+                             value=', '.join(clean_csruvs))
+        else:
+            yield Result(self, constants.SUCCESS,
+                         name='dangling_ruv',
+                         value='No dangling RUVs found')
+            yield Result(self, constants.SUCCESS,
+                         name='dangling_csruv',
+                         value='No dangling CS RUVs found')

--- a/src/ipahealthcheck/ds/ruv.py
+++ b/src/ipahealthcheck/ds/ruv.py
@@ -2,12 +2,19 @@
 # Copyright (C) 2020 FreeIPA Contributors see COPYING for license
 #
 
+import logging
+import re
+from urllib.parse import urlparse
+
 from ipahealthcheck.ds.plugin import DSPlugin, registry
 from ipahealthcheck.core.plugin import Result
 from ipahealthcheck.core.plugin import duration
 from ipahealthcheck.core import constants
-from ipalib import api
+
+from ipalib import api, errors
 from ipapython.dn import DN
+
+logger = logging.getLogger()
 
 
 @registry
@@ -22,6 +29,7 @@ class RUVCheck(DSPlugin):
     requires = ('dirsrv',)
 
     def get_ruv(self, dn):
+        """Identify the RUV for a suffix on this master"""
         try:
             entry = self.conn.get_entry(dn)
         except Exception:
@@ -44,3 +52,65 @@ class RUVCheck(DSPlugin):
             yield Result(self, constants.SUCCESS,
                          key='o=ipaca',
                          ruv=csruv)
+
+
+@registry
+class KnownRUVCheck(DSPlugin):
+    """Return all known RUVs. This can be used to identify "dangling"
+       RUVs, or left-overs from previous replication agreements.
+    """
+    requires = ('dirsrv',)
+
+    def get_all_ruvs(self, suffix):
+        """Get all known RUVs on this master
+
+           Return the RUV entries as a list of tuples: (hostname, rid)
+        """
+        search_filter = '(&(nsuniqueid=ffffffff-ffffffff-ffffffff-ffffffff)' \
+                        '(objectclass=nstombstone))'
+        try:
+            entries = self.conn.get_entries(
+                suffix, self.conn.SCOPE_SUBTREE, search_filter,
+                ['nsds50ruv'])
+        except errors.NotFound:
+            logger.debug("No RUV records found.")
+            return []
+            # raise NoRUVsFound("No RUV records found.")
+
+        servers = []
+        for e in entries:
+            for ruv in e['nsds50ruv']:
+                if ruv.startswith('{replicageneration'):
+                    continue
+                data = re.match(
+                    r'\{replica (\d+) (ldap://.*:\d+)\}(\s+\w+\s+\w*){0,1}',
+                    ruv
+                )
+                if data:
+                    rid = data.group(1)
+                    (
+                        _scheme, netloc, _path, _params, _query, _fragment
+                    ) = urlparse(data.group(2))
+                    servers.append((re.sub(r':\d+', '', netloc), rid))
+                else:
+                    logger.debug("Unable to decode RUV: %s" % ruv)
+
+        return servers
+
+    @duration
+    def check(self):
+
+        ruvs = self.get_all_ruvs(api.env.basedn)
+        csruvs = self.get_all_ruvs(DN('o=ipaca'))
+
+        if ruvs:
+            yield Result(self, constants.SUCCESS,
+                         key='ruvs_' + str(api.env.basedn),
+                         suffix=str(api.env.basedn),
+                         ruvs=ruvs)
+
+        if csruvs:
+            yield Result(self, constants.SUCCESS,
+                         key='ruvs_o=ipaca',
+                         suffix='o=ipaca',
+                         ruvs=csruvs)

--- a/src/ipahealthcheck/ipa/meta.py
+++ b/src/ipahealthcheck/ipa/meta.py
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+from ipahealthcheck.core import constants
+from ipahealthcheck.core.plugin import Result, duration
+from ipahealthcheck.ipa.plugin import IPAPlugin, registry
+from ipalib import api
+
+
+@registry
+class IPAMetaCheck(IPAPlugin):
+    """Return meta data for the IPA installation"""
+    @duration
+    def check(self):
+        try:
+            result = api.Command.server_find(pkey_only=True)
+        except Exception as e:
+            yield Result(self, constants.ERROR,
+                         msg='server-show failed, %s' % e)
+        else:
+            masters = []
+            for server in result['result']:
+                masters.append(server['cn'][0])
+            yield Result(self, constants.SUCCESS,
+                         masters=masters)

--- a/tests/clusterdata.py
+++ b/tests/clusterdata.py
@@ -1,0 +1,895 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+
+ONE_MASTER = {
+    'ipa.ipa.example': [
+        {
+            "source": "ipahealthcheck.meta.core",
+            "check": "MetaCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "fqdn": "ipa.ipa.example",
+              "ipa_version": "4.8.4",
+              "ipa_api_version": "2.235"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ipa.meta",
+          "check": "IPAMetaCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "masters": [
+              "ipa.ipa.example",
+            ]
+          }
+        },
+        # No RUV's on a freshly installed master
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+            }
+        },
+    ]
+}
+
+
+THREE_MASTERS_OK = {
+    'ipa.ipa.example': [
+        {
+            "source": "ipahealthcheck.meta.core",
+            "check": "MetaCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "fqdn": "ipa.ipa.example",
+              "ipa_version": "4.8.4",
+              "ipa_api_version": "2.235"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ipa.meta",
+          "check": "IPAMetaCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "masters": [
+              "ipa.ipa.example",
+              "replica1.ipa.example",
+              "replica2.ipa.example"
+            ]
+          }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "dc=ipa,dc=example",
+              "ruv": "4"
+            }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "o=ipaca",
+              "ruv": "6"
+            }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "KnownRUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "ruvs_dc=ipa,dc=example",
+              "suffix": "dc=ipa,dc=example",
+              "ruvs": [
+                [
+                  "ipa.ipa.example",
+                  "4"
+                ],
+                [
+                  "replica2.ipa.example",
+                  "7"
+                ],
+                [
+                  "replica1.ipa.example",
+                  "3"
+                ]
+              ]
+            }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_o=ipaca",
+            "suffix": "o=ipaca",
+            "ruvs": [
+              [
+                "ipa.ipa.example",
+                "6"
+              ],
+              [
+                "replica2.ipa.example",
+                "8"
+              ],
+              [
+                "replica1.ipa.example",
+                "5"
+              ]
+            ]
+          }
+        }
+    ],
+    'replica1.ipa.example': [
+        {
+            "source": "ipahealthcheck.meta.core",
+            "check": "MetaCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "fqdn": "replica1.ipa.example",
+              "masters": [
+                "ipa.ipa.example",
+                "replica1.ipa.example",
+                "replica2.ipa.example",
+              ],
+              "ipa_version": "4.8.4",
+              "ipa_api_version": "2.235"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ipa.meta",
+          "check": "IPAMetaCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "masters": [
+              "ipa.ipa.example",
+              "replica1.ipa.example",
+              "replica2.ipa.example"
+            ]
+          }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "dc=ipa,dc=example",
+              "ruv": "3"
+            }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "o=ipaca",
+              "ruv": "5"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_dc=ipa,dc=example",
+            "suffix": "dc=ipa,dc=example",
+            "ruvs": [
+              [
+                "replica1.ipa.example",
+                "3"
+              ],
+              [
+                "ipa.ipa.example",
+                "4"
+              ],
+              [
+                "replica2.ipa.example",
+                "7"
+              ]
+            ]
+          }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_o=ipaca",
+            "suffix": "o=ipaca",
+            "ruvs": [
+              [
+                "replica1.ipa.example",
+                "5"
+              ],
+              [
+                "ipa.ipa.example",
+                "6"
+              ],
+              [
+                "replica2.ipa.example",
+                "8"
+              ]
+            ]
+          }
+        }
+    ],
+    'replica2.ipa.example': [
+        {
+            "source": "ipahealthcheck.meta.core",
+            "check": "MetaCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "fqdn": "replica2.ipa.example",
+              "masters": [
+                "ipa.ipa.example",
+                "replica1.ipa.example",
+                "replica2.ipa.example",
+              ],
+              "ipa_version": "4.8.4",
+              "ipa_api_version": "2.235"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ipa.meta",
+          "check": "IPAMetaCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "masters": [
+              "ipa.ipa.example",
+              "replica1.ipa.example",
+              "replica2.ipa.example"
+            ]
+          }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "dc=ipa,dc=example",
+              "ruv": "7"
+            }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "o=ipaca",
+              "ruv": "8"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_dc=ipa,dc=example",
+            "suffix": "dc=ipa,dc=example",
+            "ruvs": [
+              [
+                "replica2.ipa.example",
+                "7"
+              ],
+              [
+                "ipa.ipa.example",
+                "4"
+              ],
+              [
+                "replica1.ipa.example",
+                "3"
+              ]
+            ]
+          }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_o=ipaca",
+            "suffix": "o=ipaca",
+            "ruvs": [
+              [
+                "replica2.ipa.example",
+                "8"
+              ],
+              [
+                "ipa.ipa.example",
+                "6"
+              ],
+              [
+                "replica1.ipa.example",
+                "5"
+              ]
+            ]
+          }
+        }
+    ]
+}
+
+
+#
+# Same three masters but replica1 has an extra RUV value
+#
+THREE_MASTERS_BAD_IPA_RUV = {
+    'ipa.ipa.example': [
+        {
+            "source": "ipahealthcheck.meta.core",
+            "check": "MetaCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "fqdn": "ipa.ipa.example",
+              "masters": [
+                "ipa.ipa.example",
+                "replica1.ipa.example",
+                "replica2.ipa.example",
+              ],
+              "ipa_version": "4.8.4",
+              "ipa_api_version": "2.235"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ipa.meta",
+          "check": "IPAMetaCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "masters": [
+              "ipa.ipa.example",
+              "replica1.ipa.example",
+              "replica2.ipa.example"
+            ]
+          }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "dc=ipa,dc=example",
+              "ruv": "4"
+            }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "o=ipaca",
+              "ruv": "6"
+            }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "KnownRUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "ruvs_dc=ipa,dc=example",
+              "suffix": "dc=ipa,dc=example",
+              "ruvs": [
+                [
+                  "ipa.ipa.example",
+                  "4"
+                ],
+                [
+                  "replica2.ipa.example",
+                  "7"
+                ],
+                [
+                  "replica1.ipa.example",
+                  "3"
+                ],
+                [
+                  "replica1.ipa.example",
+                  "9"
+                ]
+              ]
+            }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_o=ipaca",
+            "suffix": "o=ipaca",
+            "ruvs": [
+              [
+                "ipa.ipa.example",
+                "6"
+              ],
+              [
+                "replica2.ipa.example",
+                "8"
+              ],
+              [
+                "replica1.ipa.example",
+                "5"
+              ]
+            ]
+          }
+        }
+    ],
+    'replica1.ipa.example': [
+        {
+            "source": "ipahealthcheck.meta.core",
+            "check": "MetaCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "fqdn": "replica1.ipa.example",
+              "masters": [
+                "ipa.ipa.example",
+                "replica1.ipa.example",
+                "replica2.ipa.example",
+              ],
+              "ipa_version": "4.8.4",
+              "ipa_api_version": "2.235"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ipa.meta",
+          "check": "IPAMetaCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "masters": [
+              "ipa.ipa.example",
+              "replica1.ipa.example",
+              "replica2.ipa.example"
+            ]
+          }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "dc=ipa,dc=example",
+              "ruv": "3"
+            }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "o=ipaca",
+              "ruv": "5"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_dc=ipa,dc=example",
+            "suffix": "dc=ipa,dc=example",
+            "ruvs": [
+              [
+                "replica1.ipa.example",
+                "3"
+              ],
+              [
+                "ipa.ipa.example",
+                "4"
+              ],
+              [
+                "replica2.ipa.example",
+                "7"
+              ]
+            ]
+          }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_o=ipaca",
+            "suffix": "o=ipaca",
+            "ruvs": [
+              [
+                "replica1.ipa.example",
+                "5"
+              ],
+              [
+                "ipa.ipa.example",
+                "6"
+              ],
+              [
+                "replica2.ipa.example",
+                "8"
+              ]
+            ]
+          }
+        }
+    ],
+    'replica2.ipa.example': [
+        {
+            "source": "ipahealthcheck.meta.core",
+            "check": "MetaCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "fqdn": "replica2.ipa.example",
+              "masters": [
+                "ipa.ipa.example",
+                "replica1.ipa.example",
+                "replica2.ipa.example",
+              ],
+              "ipa_version": "4.8.4",
+              "ipa_api_version": "2.235"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ipa.meta",
+          "check": "IPAMetaCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "masters": [
+              "ipa.ipa.example",
+              "replica1.ipa.example",
+              "replica2.ipa.example"
+            ]
+          }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "dc=ipa,dc=example",
+              "ruv": "7"
+            }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "o=ipaca",
+              "ruv": "8"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_dc=ipa,dc=example",
+            "suffix": "dc=ipa,dc=example",
+            "ruvs": [
+              [
+                "replica2.ipa.example",
+                "7"
+              ],
+              [
+                "ipa.ipa.example",
+                "4"
+              ],
+              [
+                "replica1.ipa.example",
+                "3"
+              ]
+            ]
+          }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_o=ipaca",
+            "suffix": "o=ipaca",
+            "ruvs": [
+              [
+                "replica2.ipa.example",
+                "8"
+              ],
+              [
+                "ipa.ipa.example",
+                "6"
+              ],
+              [
+                "replica1.ipa.example",
+                "5"
+              ]
+            ]
+          }
+        }
+    ]
+}
+
+
+#
+# Same three masters but replica2 CA has an extra RUV value
+#
+THREE_MASTERS_BAD_CS_RUV = {
+    'ipa.ipa.example': [
+        {
+            "source": "ipahealthcheck.meta.core",
+            "check": "MetaCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "fqdn": "ipa.ipa.example",
+              "masters": [
+                "ipa.ipa.example",
+                "replica1.ipa.example",
+                "replica2.ipa.example",
+              ],
+              "ipa_version": "4.8.4",
+              "ipa_api_version": "2.235"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ipa.meta",
+          "check": "IPAMetaCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "masters": [
+              "ipa.ipa.example",
+              "replica1.ipa.example",
+              "replica2.ipa.example"
+            ]
+          }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "dc=ipa,dc=example",
+              "ruv": "4"
+            }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "o=ipaca",
+              "ruv": "6"
+            }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "KnownRUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "ruvs_dc=ipa,dc=example",
+              "suffix": "dc=ipa,dc=example",
+              "ruvs": [
+                [
+                  "ipa.ipa.example",
+                  "4"
+                ],
+                [
+                  "replica2.ipa.example",
+                  "7"
+                ],
+                [
+                  "replica1.ipa.example",
+                  "3"
+                ],
+              ]
+            }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_o=ipaca",
+            "suffix": "o=ipaca",
+            "ruvs": [
+              [
+                "ipa.ipa.example",
+                "6"
+              ],
+              [
+                "replica2.ipa.example",
+                "8"
+              ],
+              [
+                "replica1.ipa.example",
+                "5"
+              ]
+            ]
+          }
+        }
+    ],
+    'replica1.ipa.example': [
+        {
+            "source": "ipahealthcheck.meta.core",
+            "check": "MetaCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "fqdn": "replica1.ipa.example",
+              "masters": [
+                "ipa.ipa.example",
+                "replica1.ipa.example",
+                "replica2.ipa.example",
+              ],
+              "ipa_version": "4.8.4",
+              "ipa_api_version": "2.235"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ipa.meta",
+          "check": "IPAMetaCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "masters": [
+              "ipa.ipa.example",
+              "replica1.ipa.example",
+              "replica2.ipa.example"
+            ]
+          }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "dc=ipa,dc=example",
+              "ruv": "3"
+            }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "o=ipaca",
+              "ruv": "5"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_dc=ipa,dc=example",
+            "suffix": "dc=ipa,dc=example",
+            "ruvs": [
+              [
+                "replica1.ipa.example",
+                "3"
+              ],
+              [
+                "ipa.ipa.example",
+                "4"
+              ],
+              [
+                "replica2.ipa.example",
+                "7"
+              ]
+            ]
+          }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_o=ipaca",
+            "suffix": "o=ipaca",
+            "ruvs": [
+              [
+                "replica1.ipa.example",
+                "5"
+              ],
+              [
+                "ipa.ipa.example",
+                "6"
+              ],
+              [
+                "replica2.ipa.example",
+                "8"
+              ]
+            ]
+          }
+        }
+    ],
+    'replica2.ipa.example': [
+        {
+            "source": "ipahealthcheck.meta.core",
+            "check": "MetaCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "fqdn": "replica2.ipa.example",
+              "masters": [
+                "ipa.ipa.example",
+                "replica1.ipa.example",
+                "replica2.ipa.example",
+              ],
+              "ipa_version": "4.8.4",
+              "ipa_api_version": "2.235"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ipa.meta",
+          "check": "IPAMetaCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "masters": [
+              "ipa.ipa.example",
+              "replica1.ipa.example",
+              "replica2.ipa.example"
+            ]
+          }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "dc=ipa,dc=example",
+              "ruv": "7"
+            }
+        },
+        {
+            "source": "ipahealthcheck.ds.ruv",
+            "check": "RUVCheck",
+            "result": "SUCCESS",
+            "kw": {
+              "key": "o=ipaca",
+              "ruv": "8"
+            }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_dc=ipa,dc=example",
+            "suffix": "dc=ipa,dc=example",
+            "ruvs": [
+              [
+                "replica2.ipa.example",
+                "7"
+              ],
+              [
+                "ipa.ipa.example",
+                "4"
+              ],
+              [
+                "replica1.ipa.example",
+                "3"
+              ]
+            ]
+          }
+        },
+        {
+          "source": "ipahealthcheck.ds.ruv",
+          "check": "KnownRUVCheck",
+          "result": "SUCCESS",
+          "kw": {
+            "key": "ruvs_o=ipaca",
+            "suffix": "o=ipaca",
+            "ruvs": [
+              [
+                "replica2.ipa.example",
+                "8"
+              ],
+              [
+                "ipa.ipa.example",
+                "6"
+              ],
+              [
+                "replica1.ipa.example",
+                "5"
+              ],
+              [
+                "replica1.ipa.example",
+                "9"
+              ]
+            ]
+          }
+        }
+    ]
+}

--- a/tests/test_cluster_ruv.py
+++ b/tests/test_cluster_ruv.py
@@ -1,0 +1,106 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+from base import BaseTest
+from util import capture_results
+
+from ipahealthcheck.core import config
+from ipaclustercheck.ipa.plugin import ClusterRegistry
+from ipaclustercheck.ipa.ruv import ClusterRUVCheck
+
+import clusterdata
+
+
+class TestRegistry(ClusterRegistry):
+    def load_files(self, dir):
+        self.json = dir
+
+
+class Options:
+    def __init__(self, data):
+        self.data = data
+
+    @property
+    def dir(self):
+        return self.data
+
+
+registry = TestRegistry()
+
+
+class TestClusterRUV(BaseTest):
+
+    def test_no_ruvs(self):
+        """Single master test that has never created a replica
+
+           This type of master will have no RUVs created at all.
+        """
+        framework = object()
+        registry.initialize(framework, config.Config,
+                            Options(clusterdata.ONE_MASTER))
+        f = ClusterRUVCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+        result = self.results.results[0]
+        assert result.kw.get('name') == 'dangling_ruv'
+        assert result.kw.get('value') == 'No dangling RUVs found'
+        result = self.results.results[1]
+        assert result.kw.get('name') == 'dangling_csruv'
+        assert result.kw.get('value') == 'No dangling CS RUVs found'
+
+    def test_six_ruvs_ok(self):
+        """Three master test with each having a CA, no dangling
+        """
+        framework = object()
+        registry.initialize(framework, config.Config,
+                            Options(clusterdata.THREE_MASTERS_OK))
+        f = ClusterRUVCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+        result = self.results.results[0]
+        assert result.kw.get('name') == 'dangling_ruv'
+        assert result.kw.get('value') == 'No dangling RUVs found'
+        result = self.results.results[1]
+        assert result.kw.get('name') == 'dangling_csruv'
+        assert result.kw.get('value') == 'No dangling CS RUVs found'
+
+    def test_six_ruvs_ipa_bad(self):
+        """Three master test with each having a CA, dangling IPA RUV
+        """
+        framework = object()
+        registry.initialize(framework, config.Config,
+                            Options(clusterdata.THREE_MASTERS_BAD_IPA_RUV))
+        f = ClusterRUVCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+        result = self.results.results[0]
+        assert result.kw.get('name') == 'dangling_ruv'
+        assert result.kw.get('value') == '9'
+        result = self.results.results[1]
+        assert result.kw.get('name') == 'dangling_csruv'
+        assert result.kw.get('value') == 'No dangling CS RUVs found'
+
+    def test_six_ruvs_cs_bad(self):
+        """Three master test with each having a CA, dangling CA RUV
+        """
+        framework = object()
+        registry.initialize(framework, config.Config,
+                            Options(clusterdata.THREE_MASTERS_BAD_CS_RUV))
+        f = ClusterRUVCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 2
+        result = self.results.results[0]
+        assert result.kw.get('name') == 'dangling_ruv'
+        assert result.kw.get('value') == 'No dangling RUVs found'
+        result = self.results.results[1]
+        assert result.kw.get('name') == 'dangling_csruv'
+        assert result.kw.get('value') == '9'


### PR DESCRIPTION
Add Cluster RUV checking. It does a similar test that ipa-replica-manage clean-dangling-ruv does.

It also:
- adds new IPA Meta to provide the full list of known masters. This isn't yet compared internally. We'll need to decide whether to take the longest version, throw up if things don't match, etc.
- test for cluster RUV. The data is a bit of a downer, it may need to be moved to discrete files for better readability if it grows any more.
- A few small tweaks to the general cluster reporting framework.