### PR TITLE
Change default logging to display WARNING level

### DIFF
--- a/man/man8/ipa-healthcheck.8
+++ b/man/man8/ipa-healthcheck.8
@@ -45,6 +45,9 @@ Exclude SUCCESS results on output.
 \fB\-\-severity=\fRSEVERITY\fR
 Only report errors in the requested severity of SUCCESS, WARNING, ERROR or CRITICAL. This can be provided multiple times to search on multiple levels.
 .TP
+\fB\-\-verbose\fR
+Generate verbose output.
+.TP
 \fB\-\-debug\fR
 Generate additional debugging output.
 

--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -136,6 +136,8 @@ def list_sources(plugins):
 def add_default_options(parser, output_registry, default_output):
     output_names = [plugin.__name__.lower() for
                     plugin in output_registry.plugins]
+    parser.add_argument('--verbose', dest='verbose', action='store_true',
+                        default=False, help='Run in verbose mode')
     parser.add_argument('--debug', dest='debug', action='store_true',
                         default=False, help='Include debug output')
     parser.add_argument('--list-sources', dest='list_sources',
@@ -218,7 +220,7 @@ class RunChecks:
         plugins = []
         output = constants.DEFAULT_OUTPUT
 
-        logger.setLevel(logging.INFO)
+        logger.setLevel(logging.WARNING)
 
         add_default_options(self.parser, self.output_registry,
                             self.default_output)
@@ -229,6 +231,9 @@ class RunChecks:
         rval = self.validate_options()
         if rval:
             return rval
+
+        if options.verbose:
+            logger.setLevel(logging.INFO)
 
         if options.debug:
             logger.setLevel(logging.DEBUG)

--- a/tests/test_ipa_opensslvalidation.py
+++ b/tests/test_ipa_opensslvalidation.py
@@ -23,7 +23,7 @@ class TestOpenSSLValidation(BaseTest):
         def run(args, raiseonerr=True):
             result = _RunResult('', '', 0)
             result.raw_output = bytes(
-                '%s: OK'.format(args[-1]).encode('utf-8'))
+                '{}: OK'.format(args[-1]).encode('utf-8'))
             result.raw_error_output = b''
             return result
 
@@ -49,7 +49,7 @@ class TestOpenSSLValidation(BaseTest):
             result.raw_output = bytes(
                 'O = EXAMPLE.TEST, CN = ipa.example.test\n'
                 'error 20 at 0 depth lookup: unable to get local issuer '
-                'certificate\nerror %s: verification failed'.format(args[-1])
+                'certificate\nerror {}: verification failed'.format(args[-1])
                 .encode('utf-8'))
             result.raw_error_output = b''
             result.error_log = ''


### PR DESCRIPTION
This patch sets the default logging to WARNING and
adds a new CLI option `--verbose` to print
INFO level information.

This avoids printing of verbose data from `pki-healthcheck`

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`