### PR TITLE
enhance --source to specify source namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ and
 
 It is possible to execute a single check or all checks in a single source by passing --source and/or --check on the command-line. This is intended to help user's quickly ensure that something is fixed by re-running a check after making a change.
 
+`--source`, when used on its own i.e. without `--check`, can also
+accept a module *namespace* and all sources within that namespace
+shall be executed.
+
 # Output
 
 Output is controlled via Output plugins. These take the global Results object and iterate over it to produce output in the desired format. The result is returned as a string.

--- a/man/man8/ipa-healthcheck.8
+++ b/man/man8/ipa-healthcheck.8
@@ -31,10 +31,10 @@ Display a list of the available sources and the checks associated with those sou
 .SS "OPTIONAL ARGUMENTS"
 .TP
 \fB\-\-source\fR=\fISOURCE\fR
-Execute one or more checks within this given source.
+Execute checks within the named source, or all sources in the given namespace.
 .TP
 \fB\-\-check\fR=\fICHECK\fR
-Execute this particular check within a source. A source must be supplied as well with this option.
+Execute this particular check within a source. The exact source must also be specified via \fB\-\-source\fR.
 .TP
 \fB\-\-output\-type\fR=\fITYPE\fR
 Set the output type. Supported variants are \fBhuman\fR and \fBjson\fR. The default is \fBjson\fR.

--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -55,7 +55,10 @@ def source_or_check_matches(plugin, source, check):
     """Determine whether a given a plugin matches if a source
        and optional check are provided.
     """
-    if source is not None and plugin.__module__ != source:
+    if (
+        source is not None and
+        not _is_prefix_of_source(source, plugin.__module__)
+    ):
         return False
 
     if check and plugin.__class__.__name__ != check:
@@ -179,10 +182,21 @@ def limit_results(results, source, check):
     """Return ony those results which match source and/or check"""
     new_results = Results()
     for result in results.results:
-        if result.source == source:
-            if check is None or result.check == check:
+        if check is None:
+            # treat 'source' as prefix
+            if _is_prefix_of_source(source, result.source):
+                new_results.add(result)
+        else:
+            # when 'check' is given, match source fully
+            if result.source == source and result.check == check:
                 new_results.add(result)
     return new_results
+
+
+def _is_prefix_of_source(prefix, source):
+    prefix_parts = prefix.split('.')
+    source_parts = source.split('.')
+    return source_parts[:len(prefix_parts)] == prefix_parts
 
 
 class RunChecks:


### PR DESCRIPTION
As a FreeIPA developer I want ipa-healthcheck to be able to execute
all sources in a given namespace, excluding others, so that
addition/removal of checks by other projects (e.g. Dogtag) does not
affect test results.

Enhance the --source option such that its argument is treated as a
namespace.