### PR TITLE
Don't completely fail if a registry fails to initialize

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -264,8 +264,8 @@ class RunChecks:
             try:
                 registry.initialize(framework, config, options)
             except Exception as e:
-                print("Unable to initialize %s: %s" % (name, e))
-                return 1
+                logger.error("Unable to initialize %s: %s" % (name, e))
+                continue
             for plugin in find_plugins(name, registry):
                 plugins.append(plugin)
 


### PR DESCRIPTION
Log the error if registry initialization fails. This will
suppress a bad plugin from preventing healthcheck from
executing at all.

Currently this will only be reported on stdout so it won't
be immediately obvious that an entire registry is skipped.