### PR TITLE
Default to failures-only when stdin is a tty

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The major areas currently covered are:
 # How to use it?
 
 The simplest way to use Healthcheck is to run it from the command-line as root as ipa-healthcheck. Running from the command-line will display the output to the console unless --output-file=FILENAME is used.
-There is output for _all_ tests so we can be sure that an error condition isn't providing a false positive. The command-line option --failures-only will skip printing the SUCCESS conditions.
+There is output for _all_ tests so we can be sure that an error condition isn't providing a false positive. The command-line option --failures-only will skip printing the SUCCESS conditions. If running in a tty and not using --output-file then --failures-only defaults to True. The --all option will display all output if you want/need it.
 
 To automate running Healthcheck every day a systemd timer can be used. 
 The default destination directory for healthcheck logs is `/var/log/ipa/healthcheck` and this can be the input into a monitoring system to track changes over time or to alert if a test goes from working to error or warning.

--- a/man/man8/ipa-healthcheck.8
+++ b/man/man8/ipa-healthcheck.8
@@ -40,7 +40,10 @@ Execute this particular check within a source. The exact source must also be spe
 Set the output type. Supported variants are \fBhuman\fR and \fBjson\fR. The default is \fBjson\fR.
 .TP
 \fB\-\-failures\-only\fR
-Exclude SUCCESS results on output.
+Exclude SUCCESS results on output. If stdin is a tty then this will default to True. In all other cases it defaults to False.
+.TP
+\fB\-\-all\fR
+Report all results.
 .TP
 \fB\-\-severity=\fRSEVERITY\fR
 Only report errors in the requested severity of SUCCESS, WARNING, ERROR or CRITICAL. This can be provided multiple times to search on multiple levels.

--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -24,7 +24,11 @@ class IPAChecks(RunChecks):
                             help='File to read as input')
         parser.add_argument('--failures-only', dest='failures_only',
                             action='store_true', default=False,
-                            help='Exclude SUCCESS results on output')
+                            help='Exclude SUCCESS results on output (see'
+                            'man page for more details)')
+        parser.add_argument('--all', dest='all',
+                            action='store_true', default=False,
+                            help='Report all results on output')
         parser.add_argument('--severity', dest='severity', action="append",
                             help='Include only the selected severity(s)',
                             choices=[key for key in constants._nameToLevel])

--- a/src/ipahealthcheck/core/output.py
+++ b/src/ipahealthcheck/core/output.py
@@ -38,6 +38,7 @@ class Output:
     def __init__(self, options):
         self.filename = options.outfile
         self.failures_only = options.failures_only
+        self.all = options.all
         self.severity = options.severity
 
     def render(self, results):
@@ -63,8 +64,14 @@ class Output:
         output = []
         for line in results.output():
             result = line.get('result')
-            if self.failures_only and _nameToLevel.get(result) == SUCCESS:
-                continue
+            if _nameToLevel.get(result) == SUCCESS:
+                if self.failures_only:
+                    continue
+                if (not self.all and
+                    self.filename is None and
+                    not (self.failures_only is False and
+                         not sys.stdin.isatty())):
+                    continue
             if self.severity is not None and result not in self.severity:
                 continue
             output.append(line)


### PR DESCRIPTION
It is annoying and confusing to have to provide --failures-only
every time ipa-healthcheck is run on a console. Most users just
want to see what is wrong. So if stdin is a tty (this allows
pipes and redirects) and a new --all option is not set and no
--output-file is set then default to failures-only.

This still allows all combinations of output options but gives
more control and expected output to a user trying to see if their
install is good, after an upgrade for example.