### PR TITLE
Fix recursion in Config object

### DIFF
--- a/src/ipahealthcheck/core/config.py
+++ b/src/ipahealthcheck/core/config.py
@@ -30,7 +30,7 @@ class Config:
     """
 
     def __init__(self):
-        self.__d = dict()
+        object.__setattr__(self, '_Config__d', {})
 
     def __setattr__(self, key, value):
         """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,3 +41,22 @@ def test_config_values():
         pass
     else:
         assert('KeyError not raised')
+
+
+def test_config_recursion():
+    with tempfile.NamedTemporaryFile('w') as f:
+        f.write('[default]\nfoo = bar\n')
+        f.flush()
+
+        config = read_config(f.name)
+
+    assert config.foo == 'bar'
+
+    # The config dict is in the object
+    config._Config__d
+
+    # But it isn't recursive
+    try:
+        config._Config__d['_Config__d']
+    except KeyError:
+        pass


### PR DESCRIPTION
 Fix recursion in the Config object
    
The data dictionary was incorrectly recursive, ala
config._Config__d['_Config__d']['_Config__d']['_Config__d'])
    
https://github.com/freeipa/freeipa-healthcheck/issues/133
Signed-off-by: Rob Crittenden <rcritten@redhat.com>
