### PR TITLE
Pytest warnings

### DIFF
--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -23,7 +23,6 @@ from ipaserver.install import certs
 from ipaserver.install import dsinstance
 from ipaserver.install import krainstance
 from ipaserver.install import krbinstance
-from ipaserver.install import installutils
 from ipaserver.plugins import ldap2
 from ipapython import certdb
 from ipapython import ipautil
@@ -550,7 +549,7 @@ class IPANSSChainValidation(IPAPlugin):
                                      key=key)
         finally:
             if ca_pw_fname:
-                installutils.remove_file(ca_pw_fname)
+                ipautil.remove_file(ca_pw_fname)
 
 
 @registry

--- a/src/ipahealthcheck/ipa/host.py
+++ b/src/ipahealthcheck/ipa/host.py
@@ -14,7 +14,7 @@ from ipahealthcheck.core import constants
 from ipalib import api
 from ipalib.install.kinit import kinit_keytab
 from ipaplatform.paths import paths
-from ipaserver.install import installutils
+from ipapython import ipautil
 
 
 logger = logging.getLogger()
@@ -38,5 +38,5 @@ class IPAHostKeytab(IPAPlugin):
                 yield Result(self, constants.ERROR,
                              msg='Failed to obtain host TGT: %s' % e)
         finally:
-            installutils.remove_file(ccache_name)
+            ipautil.remove_file(ccache_name)
             os.rmdir(ccache_dir)

--- a/tests/test_cluster_ruv.py
+++ b/tests/test_cluster_ruv.py
@@ -12,7 +12,7 @@ from ipaclustercheck.ipa.ruv import ClusterRUVCheck
 import clusterdata
 
 
-class TestRegistry(ClusterRegistry):
+class RUVRegistry(ClusterRegistry):
     def load_files(self, dir):
         self.json = dir
 
@@ -26,7 +26,7 @@ class Options:
         return self.data
 
 
-registry = TestRegistry()
+registry = RUVRegistry()
 
 
 class TestClusterRUV(BaseTest):


### PR DESCRIPTION
Fixes for Pytest warnings:
1) installutils.remove_file -> ipapython.ipautil.remove_file
2) PytestCollectionWarning about TestRegistry

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/137