### PR TITLE
Verify on trusts that the IPA admin users exists with right SID

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -115,6 +115,7 @@ m_api.env.server = 'server.ipa.example'
 m_api.env.realm = u'IPA.EXAMPLE'
 m_api.env.domain = u'ipa.example'
 m_api.env.basedn = u'dc=ipa,dc=example'
+m_api.env.container_user = DN(('cn', 'users'), ('cn', 'accounts'))
 m_api.env.container_group = DN(('cn', 'groups'), ('cn', 'accounts'))
 m_api.env.container_host = DN(('cn', 'computers'), ('cn', 'accounts'))
 m_api.env.container_sysaccounts = DN(('cn', 'sysaccounts'), ('cn', 'etc'))


### PR DESCRIPTION
The admin user is required for trusts and must have the Domain
Admin RID 500.

https://github.com/freeipa/freeipa-healthcheck/issues/120
Signed-off-by: Rob Crittenden <rcritten@redhat.com>