### PR TITLE
Report on FIPS status: enabled, disabled, inconsistent, etc.

### DIFF
--- a/src/ipahealthcheck/meta/core.py
+++ b/src/ipahealthcheck/meta/core.py
@@ -12,6 +12,9 @@ from ipapython import ipautil
 from ipapython.version import VERSION, API_VERSION
 from ipaplatform.paths import paths
 
+if 'FIPS_MODE_SETUP' not in dir(paths):
+    paths.FIPS_MODE_SETUP = '/usr/bin/fips-mode-setup'
+
 logger = logging.getLogger()
 
 

--- a/src/ipahealthcheck/meta/core.py
+++ b/src/ipahealthcheck/meta/core.py
@@ -2,18 +2,52 @@
 # Copyright (C) 2019 FreeIPA Contributors see COPYING for license
 #
 
+import logging
+import os
 import socket
 from ipahealthcheck.core import constants
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.meta.plugin import Plugin, registry
+from ipapython import ipautil
 from ipapython.version import VERSION, API_VERSION
+from ipaplatform.paths import paths
+
+logger = logging.getLogger()
 
 
 @registry
 class MetaCheck(Plugin):
     @duration
     def check(self):
-        yield Result(self, constants.SUCCESS,
+
+        rval = constants.SUCCESS
+        if not os.path.exists(paths.FIPS_MODE_SETUP):
+            fips = "missing {}".format(paths.FIPS_MODE_SETUP)
+            logger.debug('%s is not installed, skipping',
+                         paths.FIPS_MODE_SETUP)
+        else:
+            try:
+                result = ipautil.run([paths.FIPS_MODE_SETUP,
+                                      '--is-enabled'],
+                                     capture_output=True,
+                                     raiseonerr=False,)
+            except Exception as e:
+                logger.debug('fips-mode-setup failed: %s', e)
+                fips = "failed to check"
+                rval = constants.ERROR
+            else:
+                logger.debug(result.raw_output.decode('utf-8'))
+                if result.returncode == 0:
+                    fips = "enabled"
+                elif result.returncode == 1:
+                    fips = "inconsistent"
+                elif result.returncode == 2:
+                    fips = "disabled"
+                else:
+                    fips = "unknown"
+
+        yield Result(self, rval,
                      fqdn=socket.getfqdn(),
+                     fips=fips,
                      ipa_version=VERSION,
                      ipa_api_version=API_VERSION,)

--- a/src/ipahealthcheck/meta/core.py
+++ b/src/ipahealthcheck/meta/core.py
@@ -7,21 +7,13 @@ from ipahealthcheck.core import constants
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.meta.plugin import Plugin, registry
 from ipapython.version import VERSION, API_VERSION
-from ipapython.dn import DN
-from ipalib import api
 
 
 @registry
 class MetaCheck(Plugin):
     @duration
     def check(self):
-        conn = api.Backend.ldap2
-        masters_dn = DN(api.env.container_masters, api.env.basedn)
-        masters = conn.get_entries(masters_dn, conn.SCOPE_ONELEVEL)
-        known = [master.single_value['cn'] for master in masters]
-
         yield Result(self, constants.SUCCESS,
                      fqdn=socket.getfqdn(),
-                     masters=known,
                      ipa_version=VERSION,
                      ipa_api_version=API_VERSION,)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,161 @@
+#
+# Copyright (C) 2020 FreeIPA Contributors see COPYING for license
+#
+
+from base import BaseTest
+from collections import namedtuple
+from unittest.mock import patch
+from util import capture_results
+
+from ipahealthcheck.core import config, constants
+from ipahealthcheck.meta.plugin import registry
+from ipahealthcheck.meta.core import MetaCheck
+from ipapython import ipautil
+from ipaplatform.paths import paths
+
+
+class TestMetaFIPS(BaseTest):
+    @patch('os.path.exists')
+    def test_fips_no_fips_mode_setup(self, mock_exists):
+        mock_exists.return_value = False
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = MetaCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.meta.core'
+        assert result.check == 'MetaCheck'
+        assert result.kw.get('fips') == 'missing %s' % paths.FIPS_MODE_SETUP
+
+    @patch('os.path.exists')
+    @patch('ipapython.ipautil.run')
+    def test_fips_disabled(self, mock_run, mock_exists):
+        mock_exists.return_value = True
+
+        run_result = namedtuple('run', ['returncode', 'raw_output'])
+        run_result.returncode = 2
+        run_result.raw_output = b''
+
+        mock_run.return_value = run_result
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = MetaCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.meta.core'
+        assert result.check == 'MetaCheck'
+        assert result.kw.get('fips') == 'disabled'
+
+    @patch('os.path.exists')
+    @patch('ipapython.ipautil.run')
+    def test_fips_enabled(self, mock_run, mock_exists):
+        mock_exists.return_value = True
+
+        run_result = namedtuple('run', ['returncode', 'raw_output'])
+        run_result.returncode = 0
+        run_result.raw_output = b''
+
+        mock_run.return_value = run_result
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = MetaCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.meta.core'
+        assert result.check == 'MetaCheck'
+        assert result.kw.get('fips') == 'enabled'
+
+    @patch('os.path.exists')
+    @patch('ipapython.ipautil.run')
+    def test_fips_inconsistent(self, mock_run, mock_exists):
+        mock_exists.return_value = True
+
+        run_result = namedtuple('run', ['returncode', 'raw_output'])
+        run_result.returncode = 1
+        run_result.raw_output = b''
+
+        mock_run.return_value = run_result
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = MetaCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.meta.core'
+        assert result.check == 'MetaCheck'
+        assert result.kw.get('fips') == 'inconsistent'
+
+    @patch('os.path.exists')
+    @patch('ipapython.ipautil.run')
+    def test_fips_unknown(self, mock_run, mock_exists):
+        mock_exists.return_value = True
+
+        run_result = namedtuple('run', ['returncode', 'raw_output'])
+        run_result.returncode = 103
+        run_result.raw_output = b''
+
+        mock_run.return_value = run_result
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = MetaCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.meta.core'
+        assert result.check == 'MetaCheck'
+        assert result.kw.get('fips') == 'unknown'
+
+    @patch('os.path.exists')
+    @patch('ipapython.ipautil.run')
+    def test_fips_failed(self, mock_run, mock_exists):
+        mock_exists.return_value = True
+
+        run_result = namedtuple('run', ['returncode', 'raw_output'])
+        run_result.returncode = 103
+        run_result.raw_output = b''
+
+        mock_run.side_effect = ipautil.CalledProcessError(
+           1, 'fips-mode-setup', output='execution failed'
+        )
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = MetaCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.ERROR
+        assert result.source == 'ipahealthcheck.meta.core'
+        assert result.check == 'MetaCheck'
+        assert result.kw.get('fips') == 'failed to check'

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -13,6 +13,9 @@ from ipahealthcheck.meta.core import MetaCheck
 from ipapython import ipautil
 from ipaplatform.paths import paths
 
+if 'FIPS_MODE_SETUP' not in dir(paths):
+    paths.FIPS_MODE_SETUP = '/usr/bin/fips-mode-setup'
+
 
 class TestMetaFIPS(BaseTest):
     @patch('os.path.exists')


### PR DESCRIPTION
Report on FIPS status: enabled, disabled, inconsistent, etc.
    
If fips-mode-setup is installed then we can check the status
otherwise report the missing binary.
    
The script provides 3 possible return values:
0 enabled
1 inconsistent
2 disabled
    
These are handled along with a catch-all "unknown"
   
https://github.com/freeipa/freeipa-healthcheck/issues/105
