### PR TITLE
Require that dirsrv be running to run the IPAMetaCheck

### DIFF
--- a/src/ipahealthcheck/ipa/meta.py
+++ b/src/ipahealthcheck/ipa/meta.py
@@ -11,6 +11,8 @@ from ipalib import api
 @registry
 class IPAMetaCheck(IPAPlugin):
     """Return meta data for the IPA installation"""
+    requires = ('dirsrv',)
+
     @duration
     def check(self):
         try:


### PR DESCRIPTION
Without it we don't have an LDAP connection to collect the
list of servers.

Signed-off-by: Rob Crittenden <rcritten@redhat.com>