### PR TITLE
Allow consuming projects to not use all available options

### DIFF
--- a/src/ipahealthcheck/core/output.py
+++ b/src/ipahealthcheck/core/output.py
@@ -37,9 +37,19 @@ class Output:
     """
     def __init__(self, options):
         self.filename = options.outfile
-        self.failures_only = options.failures_only
-        self.all = options.all
-        self.severity = options.severity
+
+        # Non-required options in the framework, set logical defaults to
+        # pre 0.6 behavior with everything reported.
+        self.severity = None
+        self.failures_only = False
+        self.all = True
+
+        if 'failures_only' in options:
+            self.failures_only = options.failures_only
+        if 'all' in options:
+            self.all = options.all
+        if 'severity' in options:
+            self.severity = options.severity
 
     def render(self, results):
         """Process the results into output"""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,28 @@
+#
+# Copyright (C) 2020 FreeIPA Contributors see COPYING for license
+#
+
+import argparse
+
+from ipahealthcheck.core.output import output_registry
+
+
+class RunChecks:
+    def run_healthcheck(self):
+        options = argparse.Namespace(check=None, debug=False, indent=2,
+                                     list_sources=False, outfile=None,
+                                     output='json', source=None,
+                                     verbose=False)
+
+        for out in output_registry.plugins:
+            if out.__name__.lower() == options.output:
+                out(options)
+                break
+
+
+def test_run_healthcheck():
+    """
+    Test typical initialization in run_healthcheck (based ok pki-healthcheck)
+    """
+    run = RunChecks()
+    run.run_healthcheck()


### PR DESCRIPTION
Some consumers of the framework may not be interested in the
filtering options. Don't fail if some or all of those are not
defined as options. Set logical defaults in this case.

https://github.com/freeipa/freeipa-healthcheck/issues/144

Signed-off-by: Rob Crittenden <rcritten@redhat.com>