### PR TITLE
Explicitly convert cert_expiration_days to int

### DIFF
--- a/man/man5/ipahealthcheck.conf.5
+++ b/man/man5/ipahealthcheck.conf.5
@@ -40,5 +40,13 @@ The number of days left before a certificate expires to start displaying a warni
 .TP
 .I /etc/ipahealthcheck/ipahealthcheck.conf
 configuration file
+
+.SH "EXAMPLES"
+.TP
+7 days left before a certificate expires to start displaying a warning:
+
+ [default]
+ cert_expiration_days=7
+
 .SH "SEE ALSO"
 .BR ipa-healthcheck (8)

--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -207,7 +207,7 @@ class IPACertmongerExpirationCheck(IPAPlugin):
             else:
                 delta = nafter - now
                 diff = int(delta.total_seconds() / DAY)
-                if diff < self.config.cert_expiration_days:
+                if diff < int(self.config.cert_expiration_days):
                     yield Result(self, constants.WARNING,
                                  key=id,
                                  expiration_date=generalized_time(nafter),
@@ -308,7 +308,7 @@ class IPACertfileExpirationCheck(IPAPlugin):
 
             delta = notafter - now
             diff = int(delta.total_seconds() / DAY)
-            if diff < self.config.cert_expiration_days:
+            if diff < int(self.config.cert_expiration_days):
                 yield Result(self, constants.WARNING,
                              key=id,
                              expiration_date=generalized_time(notafter),
@@ -875,7 +875,7 @@ class IPACAChainExpirationCheck(IPAPlugin):
             return
 
         now = datetime.now(timezone.utc)
-        soon = now + timedelta(days=self.config.cert_expiration_days)
+        soon = now + timedelta(days=int(self.config.cert_expiration_days))
         for cert in ca_certs:
             subject = DN(cert.subject)
             subject = str(subject).replace('\\;', '\\3b')

--- a/tests/test_ipa_certfile_expiration.py
+++ b/tests/test_ipa_certfile_expiration.py
@@ -44,7 +44,7 @@ class TestIPACertificateFile(BaseTest):
         registry.initialize(framework, config.Config)
         f = IPACertfileExpirationCheck(registry)
 
-        f.config.cert_expiration_days = 28
+        f.config.cert_expiration_days = '28'
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -67,7 +67,7 @@ class TestIPACertificateFile(BaseTest):
         registry.initialize(framework, config.Config)
         f = IPACertfileExpirationCheck(registry)
 
-        f.config.cert_expiration_days = 30
+        f.config.cert_expiration_days = '30'
         self.results = capture_results(f)
 
         assert len(self.results) == 1
@@ -91,7 +91,7 @@ class TestIPACertificateFile(BaseTest):
         registry.initialize(framework, config.Config)
         f = IPACertfileExpirationCheck(registry)
 
-        f.config.cert_expiration_days = 30
+        f.config.cert_expiration_days = '30'
         self.results = capture_results(f)
 
         assert len(self.results) == 1

--- a/tests/test_ipa_expiration.py
+++ b/tests/test_ipa_expiration.py
@@ -33,7 +33,7 @@ class TestExpiration(BaseTest):
         registry.initialize(framework, config.Config)
         f = IPACertmongerExpirationCheck(registry)
 
-        f.config.cert_expiration_days = 7
+        f.config.cert_expiration_days = '7'
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -67,7 +67,7 @@ class TestExpiration(BaseTest):
         registry.initialize(framework, config.Config)
         f = IPACertmongerExpirationCheck(registry)
 
-        f.config.cert_expiration_days = 30
+        f.config.cert_expiration_days = '30'
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -122,7 +122,7 @@ class TestChainExpiration(BaseTest):
         registry.initialize(framework, config.Config)
         f = IPACAChainExpirationCheck(registry)
 
-        f.config.cert_expiration_days = 7
+        f.config.cert_expiration_days = '7'
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -159,7 +159,7 @@ class TestChainExpiration(BaseTest):
         registry.initialize(framework, config.Config)
         f = IPACAChainExpirationCheck(registry)
 
-        f.config.cert_expiration_days = 7
+        f.config.cert_expiration_days = '7'
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -198,7 +198,7 @@ class TestChainExpiration(BaseTest):
         registry.initialize(framework, config.Config)
         f = IPACAChainExpirationCheck(registry)
 
-        f.config.cert_expiration_days = 7
+        f.config.cert_expiration_days = '7'
         self.results = capture_results(f)
 
         assert len(self.results) == 2
@@ -235,7 +235,7 @@ class TestChainExpiration(BaseTest):
         registry.initialize(framework, config.Config)
         f = IPACAChainExpirationCheck(registry)
 
-        f.config.cert_expiration_days = 7
+        f.config.cert_expiration_days = '7'
         self.results = capture_results(f)
 
         assert len(self.results) == 2


### PR DESCRIPTION
According to docs \[0\]:
> Supported Datatypes
Config parsers do not guess datatypes of values in configuration files,
always storing them internally as strings. This means that if you need
other datatypes, you should convert on your own.

\[0\]: https://docs.python.org/3/library/configparser.html#supported-datatypes

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/146