### PR TITLE
Support an additional trust type, don't rely on strings for type

### DIFF
--- a/src/ipahealthcheck/ipa/trust.py
+++ b/src/ipahealthcheck/ipa/trust.py
@@ -15,6 +15,10 @@ from ipalib import api
 from ipaplatform.paths import paths
 from ipapython import ipautil
 from ipapython.dn import DN
+from ipaserver.dcerpc_common import (
+    trust_type_string,
+    _trust_type_dict_unknown
+)
 
 try:
     import pysss_nss_idmap
@@ -42,16 +46,22 @@ def get_trust_domains():
 
     Each entry is a dictionary representating an AD domain.
     """
-    result = api.Command.trust_find()
+    result = api.Command.trust_find(all=True, raw=True)
     results = result['result']
     trust_domains = []
     for result in results:
-        if result.get('trusttype')[0] == 'Active Directory domain':
+        attributes = int(result.get('ipanttrustattributes', [0])[0])
+        if (
+            trust_type_string(result.get('ipanttrusttype')[0], attributes) !=
+            _trust_type_dict_unknown
+        ):
             domain = dict()
             domain['domain'] = result.get('cn')[0]
             domain['domainsid'] = result.get('ipanttrusteddomainsid')[0]
             domain['netbios'] = result.get('ipantflatname')[0]
             trust_domains.append(domain)
+        else:
+            logger.debug('Unhandled trust type %s', _trust_type_dict_unknown)
     return trust_domains
 
 

--- a/tests/test_ipa_trust.py
+++ b/tests/test_ipa_trust.py
@@ -261,13 +261,18 @@ class TestTrustDomains(BaseTest):
                     'cn': ['ad.example'],
                     'ipantflatname': ['ADROOT'],
                     'ipanttrusteddomainsid': ['S-1-5-21-abc'],
+                    'ipanttrusttype': ['2'],
+                    'ipanttrustattributes': ['8'],
                     'trusttype': ['Active Directory domain'],
                 },
                 {
                     'cn': ['child.example'],
-                    'ipantflatname': ['ADROOT'],
-                    'ipanttrusteddomainsid': ['S-1-5-21-def'],
-                    'trusttype': ['Active Directory domain'],
+                    'ipantflatname': ['ADCHILD'],
+                    'ipanttrusteddomainsid': ['S-1-5-22-def'],
+                    'ipanttrusttype': ['2'],
+                    'ipanttrustattributes': ['9'],
+                    'trusttype': ['Non-transitive external trust to a domain '
+                                  'in another Active Directory forest']
                 },
             ]
         }]
@@ -325,13 +330,18 @@ class TestTrustDomains(BaseTest):
                     'cn': ['ad.example'],
                     'ipantflatname': ['ADROOT'],
                     'ipanttrusteddomainsid': ['S-1-5-21-abc'],
+                    'ipanttrusttype': ['2'],
+                    'ipanttrustattributes': ['8'],
                     'trusttype': ['Active Directory domain'],
                 },
                 {
                     'cn': ['child.example'],
-                    'ipantflatname': ['ADROOT'],
-                    'ipanttrusteddomainsid': ['S-1-5-21-def'],
-                    'trusttype': ['Active Directory domain'],
+                    'ipantflatname': ['ADCHILD'],
+                    'ipanttrusteddomainsid': ['S-1-5-22-def'],
+                    'ipanttrusttype': ['2'],
+                    'ipanttrustattributes': ['9'],
+                    'trusttype': ['Non-transitive external trust to a domain '
+                                  'in another Active Directory forest']
                 },
             ]
         }]
@@ -441,13 +451,18 @@ class TestTrustCatalog(BaseTest):
                     'cn': ['ad.example'],
                     'ipantflatname': ['ADROOT'],
                     'ipanttrusteddomainsid': ['S-1-5-21-abc'],
+                    'ipanttrusttype': ['2'],
+                    'ipanttrustattributes': ['8'],
                     'trusttype': ['Active Directory domain'],
                 },
                 {
                     'cn': ['child.example'],
-                    'ipantflatname': ['ADROOT'],
-                    'ipanttrusteddomainsid': ['S-1-5-21-def'],
-                    'trusttype': ['Active Directory domain'],
+                    'ipantflatname': ['ADCHILD'],
+                    'ipanttrusteddomainsid': ['S-1-5-22-def'],
+                    'ipanttrusttype': ['2'],
+                    'ipanttrustattributes': ['9'],
+                    'trusttype': ['Non-transitive external trust to a domain '
+                                  'in another Active Directory forest']
                 },
             ]
         }]
@@ -487,7 +502,7 @@ class TestTrustCatalog(BaseTest):
         assert result.source == 'ipahealthcheck.ipa.trust'
         assert result.check == 'IPATrustCatalogCheck'
         assert result.kw.get('key') == 'Domain Security Identifier'
-        assert result.kw.get('sid') == 'S-1-5-21-def'
+        assert result.kw.get('sid') == 'S-1-5-22-def'
 
         result = self.results.results[4]
         assert result.result == constants.SUCCESS


### PR DESCRIPTION
ipaserver/dcerpc_common.py defines the possible trust types:

_trust_type_dict = {
 1: _('Non-Active Directory domain'),
 2: _('Active Directory domain'),
 3: _('RFC4120-compliant Kerberos realm'),
 10: _('Non-transitive external trust to a domain in '
       'another Active Directory forest'),
 11: _('Non-transitive external trust to an RFC4120-'
       'compliant Kerberos realm')
}

In practice, only '2' and '10' can appear as trust types right now.
The other three describe possible options for the attributes on AD
side. When IPA-IPA trust will be added, it will be seen as '2'.

Since this is a translated value use ipanttrusttype instead of
trusttype.

https://bugzilla.redhat.com/show_bug.cgi?id=1891505

Signed-off-by: Rob Crittenden <rcritten@redhat.com>