### PR TITLE
Allow a set of users/groups when specifying file owner/group

### DIFF
--- a/src/ipahealthcheck/ipa/files.py
+++ b/src/ipahealthcheck/ipa/files.py
@@ -92,7 +92,8 @@ class IPAFileCheck(IPAPlugin, FileCheck):
         self.files.append((paths.IPA_CA_CRT, 'root', 'root', '0644'))
         self.files.append((paths.IPA_CUSTODIA_KEYS, 'root', 'root', '0600'))
 
-        self.files.append((paths.RESOLV_CONF, 'root', 'root', '0644'))
+        self.files.append((paths.RESOLV_CONF, ('root', 'systemd-resolve'),
+                          ('root', 'systemd-resolve'), '0644'))
         self.files.append((paths.HOSTS, 'root', 'root', '0644'))
 
         return FileCheck.check(self)


### PR DESCRIPTION
If there is a single owner or group then the old message will
be returned in order to retain backwards compatibility. Otherwise
a comma-seprated list of names for owner/group will be reported
on failure.

This was first seen as necessary on Fedora 33 where /etc/resolv.conf
could be owned by systemd-resolve or root due to the introduction
of a new resolver type.

https://github.com/freeipa/freeipa-healthcheck/issues/165
Signed-off-by: Rob Crittenden <rcritten@redhat.com>