### PR TITLE
Remove deprecated options from setup.py and tox.ini

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,4 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     python_requires='!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
-    setup_requires=['pytest-runner',],
-    tests_require=['pytest',],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,6 @@ commands=
    {envpython} -m pylint --rcfile=pylintrc --load-plugins=pylint_plugins src tests
 
 [testenv:pep8]
-deps=pep8
+deps=pycodestyle
 commands=
-    {envpython} -m pep8 src/ipahealthcheck tests
+    {envpython} -m pycodestyle src/ipahealthcheck tests


### PR DESCRIPTION
Remove deprecated options from setup.py

Remove ‘pytest-runner’ from your ‘setup_requires’, preferably
removing the setup_requires option.

Remove ‘pytest’ and any other testing requirements from
‘tests_require’, preferably removing the setup_requires option.

We already use tox for basic environment setup.

https://github.com/freeipa/freeipa-healthcheck/issues/161

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

Also replace pep8 with pycodestyle.