### PR TITLE
In installation check be specific about server

### DIFF
--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -15,7 +15,7 @@ from ipaserver.install.installutils import is_ipa_configured
 class IPAChecks(RunChecks):
     def pre_check(self):
         if not is_ipa_configured():
-            print("IPA is not configured")
+            print("IPA server is not configured")
             return 1
 
         return None


### PR DESCRIPTION
Previously if IPA server was not configured the message was
"IPA is not configured." If ipa-healthcheck is run on a client
then this could be misleading.

Signed-off-by: Rob Crittenden <rcritten@redhat.com>