### PR TITLE
Check for a host certificate to avoid a false positive tracking

### DIFF
--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -145,6 +145,23 @@ def get_expected_requests(ca, ds, serverid):
     else:
         logger.debug('No KDC pkinit certificate')
 
+    # See if a host certificate was issued. This is only to
+    # prevent a false-positive if one is indeed installed.
+    local = {
+        paths.IPA_NSSDB_DIR: 'Local IPA host',
+        paths.NSS_DB_DIR: 'IPA Machine Certificate - %s' % socket.getfqdn(),
+    }
+    for db, nickname in local.items():
+        nssdb = certdb.NSSDatabase(db)
+        if nssdb.has_nickname(nickname):
+            requests.append(
+                {
+                    'cert-database': db,
+                    'cert-nickname': nickname,
+                    'ca-name': 'IPA',
+                }
+            )
+
     return requests
 
 


### PR DESCRIPTION
It is possible to have a machine certificate tracked by certmonger
for a promoted server. Include it in the list of possible
certificates for the purpose of avoid reporting a false positive
of an unknown cert.

https://github.com/freeipa/freeipa-healthcheck/issues/180

Signed-off-by: Rob Crittenden <rcritten@redhat.com>