### PR TITLE
Handle slight different in exception output in Python 3.10

### DIFF
--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -22,8 +22,8 @@ def test_Result():
     r = Result(p, constants.SUCCESS, **kw)
 
     e = raises(TypeError, Result)
-    assert str(e) == "__init__() missing 2 required positional arguments: " \
-                     "'plugin' and 'result'"
+    assert "__init__() missing 2 required positional arguments: " \
+           "'plugin' and 'result'" in str(e)
 
     # Test passing source and check to Result. This is used for loading
     # a previous output.


### PR DESCRIPTION
Python 3.10 adds the class name to the exception so a
x = Result() failure will return:

Result.__init__() missing...

instead as with previous python versions:

__init__() missing...

https://bugzilla.redhat.com/show_bug.cgi?id=1915256