### PR TITLE
Failed expected group should be a string, not a list

### DIFF
--- a/src/ipahealthcheck/core/files.py
+++ b/src/ipahealthcheck/core/files.py
@@ -98,6 +98,7 @@ class FileCheck:
                     msg = 'Group of %s is %s and should ' \
                           'be one of %s' % \
                           (path, actual.gr_name, ','.join(group))
+                group = ','.join(group)
                 yield Result(self, constants.WARNING, key=key,
                              path=path, type='group', expected=group,
                              got=actual.gr_name,

--- a/tests/test_core_files.py
+++ b/tests/test_core_files.py
@@ -67,9 +67,17 @@ def test_files_owner(mock_stat):
     results = capture_results(f)
     my_results = get_results(results, 'owner')
     assert my_results.results[0].result == constants.WARNING
+    assert my_results.results[0].kw.get('got') == 'nobody'
+    assert my_results.results[0].kw.get('expected') == 'root'
+    assert my_results.results[0].kw.get('type') == 'owner'
+
     assert my_results.results[1].result == constants.SUCCESS
     assert my_results.results[2].result == constants.SUCCESS
+
     assert my_results.results[3].result == constants.WARNING
+    assert my_results.results[3].kw.get('got') == 'nobody'
+    assert my_results.results[3].kw.get('expected') == 'root,bin'
+    assert my_results.results[3].kw.get('type') == 'owner'
     assert my_results.results[3].kw.get('msg') == \
         'Ownership of fiz is nobody and should be one of root,bin'
 
@@ -97,9 +105,17 @@ def test_files_group(mock_stat):
     results = capture_results(f)
     my_results = get_results(results, 'group')
     assert my_results.results[0].result == constants.WARNING
+    assert my_results.results[0].kw.get('got') == 'nobody'
+    assert my_results.results[0].kw.get('expected') == 'root'
+    assert my_results.results[0].kw.get('type') == 'group'
+
     assert my_results.results[1].result == constants.SUCCESS
     assert my_results.results[2].result == constants.SUCCESS
+
     assert my_results.results[3].result == constants.WARNING
+    assert my_results.results[3].kw.get('got') == 'nobody'
+    assert my_results.results[3].kw.get('expected') == 'root,bin'
+    assert my_results.results[3].kw.get('type') == 'group'
     assert my_results.results[3].kw.get('msg') == \
         'Group of fiz is nobody and should be one of root,bin'
 


### PR DESCRIPTION
This was caused by the code to allow multiple possible
file owner and group. The expected value for group wasn't
being converted into a string so was kept as a list.

Test updated to catch this situation.

https://github.com/freeipa/freeipa-healthcheck/issues/183