### PR TITLE
Return user-friendly message when no issues found

### DIFF
--- a/src/ipahealthcheck/core/output.py
+++ b/src/ipahealthcheck/core/output.py
@@ -126,6 +126,8 @@ class Human(Output):
     options = ()
 
     def generate(self, data):
+        if not data:
+            return "No issues found.\n"
         output = ''
         for line in data:
             kw = line.get('kw')


### PR DESCRIPTION
Return user-friendly message instead of empty string
when no issues found and using the "human" output type.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1780062
Signed-off-by: Antonio Torres <antorres@redhat.com>