### PR TITLE
Add checks to detect mismatch of certificates between databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,30 @@ The trust for certificates stored in NSS databases is compared against a known g
       }
     }
 
+### IPACertMatchCheck
+Ensure CA certificate entries in LDAP and NSS databases match.
+
+    {
+      "source": "ipahealthcheck.ipa.certs",
+      "check": "IPACertMatchCheck",
+      "result": "ERROR",
+      "kw": {
+        "msg": "CA Certificate from /etc/ipa/nssdb does not match /etc/ipa/ca.crt"
+      }
+    }
+
+### IPADogtagCertsMatchCheck
+Check if Dogtag certificates present in both NSS DB and LDAP match.
+
+    {
+      "source": "ipahealthcheck.ipa.certs",
+      "check": "IPADogtagCertsMatchCheck",
+      "result": "ERROR",
+      "kw": {
+        "msg": "'subsystemCert cert-pki-ca' certificate in NSS DB does not match entry in LDAP"
+      }
+    }
+
 ### IPANSSChainValidation
 Validate the certificate chain of the NSS certificates. This executes: certutil -V -u V -e -d [dbdir] -n [nickname].
 

--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -29,6 +29,7 @@ from ipaserver.plugins import ldap2
 from ipapython import certdb
 from ipapython import ipautil
 from ipapython.dn import DN
+from ipapython.ipaldap import realm_to_serverid
 
 logger = logging.getLogger()
 DAY = 60 * 60 * 24
@@ -581,6 +582,224 @@ class IPACertNSSTrust(IPAPlugin):
                 dbdir=paths.PKI_TOMCAT_ALIAS_DIR,
                 msg='Certificate {nickname} missing from {dbdir} while '
                     'verifying trust')
+
+
+@registry
+class IPACertMatchCheck(IPAPlugin):
+    """
+    Ensure certificates match between LDAP and NSS databases
+    """
+
+    requires = ('dirsrv',)
+
+    def get_cert_list_from_db(self, nssdb, nickname):
+        """
+        Retrieve all certificates from an NSS database for nickname.
+        """
+        try:
+            args = ["-L", "-n", nickname, "-a"]
+            result = nssdb.run_certutil(args, capture_output=True)
+            return x509.load_certificate_list(result.raw_output)
+        except ipautil.CalledProcessError:
+            return []
+
+    @duration
+    def check(self):
+        if not self.ca.is_configured():
+            logger.debug("No CA configured, skipping certificate match check")
+            return
+
+        # Ensure /etc/ipa/ca.crt matches the NSS DB CA certificates
+        def match_cacert_and_db(plugin, cacerts, dbpath):
+            db = certs.CertDB(api.env.realm, dbpath)
+            nickname = '%s IPA CA' % api.env.realm
+            try:
+                dbcacerts = self.get_cert_list_from_db(db, nickname)
+            except Exception as e:
+                yield Result(plugin, constants.ERROR,
+                             error=str(e),
+                             msg='Unable to load CA cert: {error}')
+                return False
+
+            ok = True
+            for cert in dbcacerts:
+                if cert not in cacerts:
+                    ok = False
+                    yield Result(plugin, constants.ERROR,
+                                 nickname=nickname,
+                                 serial_number=cert.serial_number,
+                                 dbdir=dbpath,
+                                 certdir=paths.IPA_CA_CRT,
+                                 msg=('CA Certificate nickname {nickname} '
+                                      'with serial number {serial} '
+                                      'is in {dbdir} but is not in'
+                                      '%s' % paths.IPA_CA_CRT))
+            return ok
+
+        try:
+            cacerts = x509.load_certificate_list_from_file(paths.IPA_CA_CRT)
+        except Exception:
+            yield Result(self, constants.ERROR,
+                         path=paths.IPA_CA_CRT,
+                         msg='Unable to load CA cert file {path}: {error}')
+            return
+
+        # Ensure CA cert entry from LDAP matches /etc/ipa/ca.crt
+        dn = DN('cn=%s IPA CA' % api.env.realm,
+                'cn=certificates,cn=ipa,cn=etc',
+                api.env.basedn)
+        try:
+            entry = self.conn.get_entry(dn)
+        except errors.NotFound:
+            yield Result(self, constants.ERROR,
+                         dn=str(dn),
+                         msg='CA Certificate entry \'{dn}\' '
+                             'not found in LDAP')
+            return
+
+        cacerts_ok = True
+        # Are all the certs in LDAP for the IPA CA in /etc/ipa/ca.crt
+        for cert in entry['CACertificate']:
+            if cert not in cacerts:
+                cacerts_ok = False
+                yield Result(self, constants.ERROR,
+                             dn=str(dn),
+                             serial_number=cert.serial_number,
+                             msg=('CA Certificate serial number {serial} is '
+                                  'in LDAP \'{dn}\' but is not in '
+                                  '%s' % paths.IPA_CA_CRT))
+
+        # Ensure NSS DBs have matching CA certs for /etc/ipa/ca.crt
+        serverid = realm_to_serverid(api.env.realm)
+        dspath = paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % serverid
+
+        cacertds_ok = yield from match_cacert_and_db(self, cacerts, dspath)
+        cacertnss_ok = yield from match_cacert_and_db(self, cacerts,
+                                                      paths.IPA_NSSDB_DIR)
+        if cacerts_ok:
+            yield Result(self, constants.SUCCESS,
+                         key=paths.IPA_CA_CRT)
+        if cacertds_ok:
+            yield Result(self, constants.SUCCESS,
+                         key=dspath)
+        if cacertnss_ok:
+            yield Result(self, constants.SUCCESS,
+                         key=paths.IPA_NSSDB_DIR)
+
+
+@registry
+class IPADogtagCertsMatchCheck(IPAPlugin):
+    """
+    Check if dogtag certs present in both NSS DB and LDAP match
+    """
+    requires = ('dirsrv',)
+
+    @duration
+    def check(self):
+        if not self.ca.is_configured():
+            logger.debug('CA is not configured, skipping connectivity check')
+            return
+
+        def match_ldap_nss_cert(plugin, ldap, db, cert_dn, attr, cert_nick):
+            try:
+                entry = ldap.get_entry(cert_dn)
+            except errors.NotFound:
+                yield Result(plugin, constants.ERROR,
+                             msg='%s entry not found in LDAP' % cert_dn)
+                return False
+            try:
+                nsscert = db.get_cert_from_db(cert_nick)
+            except Exception as e:
+                yield Result(plugin, constants.ERROR,
+                             error=str(e),
+                             msg=('Unable to load %s certificate:'
+                                  '{error}' % cert_nick))
+                return False
+            cert_matched = any([cert == nsscert for cert in entry[attr]])
+            if not cert_matched:
+                yield Result(plugin, constants.ERROR,
+                             key=cert_nick,
+                             nickname=cert_nick,
+                             dbdir=db.secdir,
+                             msg=('{nickname} certificate in NSS DB {dbdir} '
+                                  'does not match entry in LDAP'))
+                return False
+            return True
+
+        def match_ldap_nss_certs_by_subject(plugin, ldap, db, dn,
+                                            expected_nicks_subjects):
+            entries = ldap.get_entries(dn)
+            all_ok = True
+            for nick, subject in expected_nicks_subjects.items():
+                cert = db.get_cert_from_db(nick)
+                ok = any([cert in entry['userCertificate'] and
+                          subject == entry['subjectName'][0]
+                          for entry in entries
+                          if 'userCertificate' in entry])
+                if not ok:
+                    all_ok = False
+                    yield Result(plugin, constants.ERROR,
+                                 key=nick,
+                                 nickname=nick,
+                                 dbdir=db.secdir,
+                                 msg=('{nickname} certificate in NSS DB '
+                                      '{dbdir} does not match entry in LDAP'))
+            return all_ok
+
+        db = certs.CertDB(api.env.realm, paths.PKI_TOMCAT_ALIAS_DIR)
+        dn = DN('uid=pkidbuser,ou=people,o=ipaca')
+        subsystem_nick = 'subsystemCert cert-pki-ca'
+        subsystem_ok = yield from match_ldap_nss_cert(self, self.conn,
+                                                      db, dn,
+                                                      'userCertificate',
+                                                      subsystem_nick)
+        dn = DN('cn=%s IPA CA' % api.env.realm,
+                'cn=certificates,cn=ipa,cn=etc',
+                api.env.basedn)
+        casigning_nick = 'caSigningCert cert-pki-ca'
+        casigning_ok = yield from match_ldap_nss_cert(self, self.conn,
+                                                      db, dn, 'CACertificate',
+                                                      casigning_nick)
+
+        expected_nicks_subjects = {
+            'ocspSigningCert cert-pki-ca':
+                'CN=OCSP Subsystem,O=%s' % api.env.realm,
+            'subsystemCert cert-pki-ca':
+                'CN=CA Subsystem,O=%s' % api.env.realm,
+            'auditSigningCert cert-pki-ca':
+                'CN=CA Audit,O=%s' % api.env.realm,
+            'Server-Cert cert-pki-ca':
+                'CN=%s,O=%s' % (api.env.host, api.env.realm),
+        }
+
+        kra = krainstance.KRAInstance(api.env.realm)
+        if kra.is_installed():
+            kra_expected_nicks_subjects = {
+                'transportCert cert-pki-kra':
+                    'CN=KRA Transport Certificate,O=%s' % api.env.realm,
+                'storageCert cert-pki-kra':
+                    'CN=KRA Storage Certificate,O=%s' % api.env.realm,
+                'auditSigningCert cert-pki-kra':
+                    'CN=KRA Audit,O=%s' % api.env.realm,
+            }
+            expected_nicks_subjects.update(kra_expected_nicks_subjects)
+
+        ipaca_basedn = DN('ou=certificateRepository,ou=ca,o=ipaca')
+        ipaca_certs_ok = yield from match_ldap_nss_certs_by_subject(
+                                    self, self.conn, db,
+                                    ipaca_basedn,
+                                    expected_nicks_subjects
+                                )
+
+        if subsystem_ok:
+            yield Result(self, constants.SUCCESS,
+                         key=subsystem_nick)
+        if casigning_ok:
+            yield Result(self, constants.SUCCESS,
+                         key=casigning_nick)
+        if ipaca_certs_ok:
+            yield Result(self, constants.SUCCESS,
+                         key=str(ipaca_basedn))
 
 
 @registry

--- a/tests/test_ipa_cert_match.py
+++ b/tests/test_ipa_cert_match.py
@@ -1,0 +1,282 @@
+#
+# Copyright (C) 2021 FreeIPA Contributors see COPYING for license
+#
+
+from util import capture_results, m_api, CAInstance, KRAInstance
+from base import BaseTest
+from ipahealthcheck.core import config, constants
+from ipahealthcheck.ipa.plugin import registry
+from ipahealthcheck.ipa.certs import IPACertMatchCheck
+from ipahealthcheck.ipa.certs import IPADogtagCertsMatchCheck
+from unittest.mock import Mock, patch
+
+from ipalib import errors
+from ipapython.dn import DN
+from ipapython.ipaldap import LDAPClient, LDAPEntry
+
+
+class IPACertificate:
+    def __init__(self, serial_number=1):
+        self.serial_number = serial_number
+
+    def __eq__(self, other):
+        return self.serial_number == other.serial_number
+
+    def __hash__(self):
+        return hash(self.serial_number)
+
+
+class mock_ldap:
+    SCOPE_BASE = 1
+    SCOPE_ONELEVEL = 2
+    SCOPE_SUBTREE = 4
+
+    def __init__(self, entries):
+        """Initialize the results that we will return from get_entry"""
+        self.results = {entry.dn: entry for entry in entries}
+
+    def get_entry(self, dn, attrs_list=None, time_limit=None,
+                  size_limit=None, get_effective_rights=False):
+        if self.results is None:
+            raise errors.NotFound(reason='test')
+        return self.results[dn]
+
+    def get_entries(self, base_dn, scope=SCOPE_SUBTREE, filter=None,
+                    attrs_list=None, get_effective_rights=False, **kwargs):
+        if self.results is None:
+            raise errors.NotFound(reason='test')
+        return self.results.values()
+
+
+class mock_ldap_conn:
+    def set_option(self, option, invalue):
+        pass
+
+    def search_s(self, base, scope, filterstr=None,
+                 attrlist=None, attrsonly=0):
+        return tuple()
+
+
+class mock_CertDB:
+    def __init__(self, trust):
+        """A dict of nickname + NSSdb trust flags"""
+        self.trust = trust
+        self.secdir = '/foo/bar/testdir'
+
+    def get_cert_from_db(self, nickname):
+        if nickname not in self.trust.keys():
+            raise errors.NotFound(reason='test')
+        return IPACertificate()
+
+    def run_certutil(self, args, capture_output):
+        class RunResult:
+            def __init__(self, output):
+                self.raw_output = output
+
+        return RunResult(b'test output')
+
+
+class TestIPACertMatch(BaseTest):
+    patches = {
+        'ldap.initialize':
+        Mock(return_value=mock_ldap_conn())
+    }
+
+    @patch('ipalib.x509.load_certificate_list_from_file')
+    @patch('ipaserver.install.certs.CertDB')
+    def test_certs_match_ok(self, mock_certdb, mock_load_cert):
+        """ Ensure match check is ok"""
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        cacertentry = LDAPEntry(fake_conn,
+                                DN('cn=%s IPA CA' % m_api.env.realm,
+                                   'cn=certificates,cn=ipa,cn=etc',
+                                    m_api.env.basedn),
+                                CACertificate=[IPACertificate()])
+        trust = {
+            ('%s IPA CA' % m_api.env.realm): 'u,u,u'
+        }
+
+        mock_certdb.return_value = mock_CertDB(trust)
+        mock_load_cert.return_value = [IPACertificate()]
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = IPACertMatchCheck(registry)
+        f.conn = mock_ldap([cacertentry])
+        self.results = capture_results(f)
+
+        assert len(self.results) == 3
+        for result in self.results.results:
+            assert result.result == constants.SUCCESS
+            assert result.source == 'ipahealthcheck.ipa.certs'
+            assert result.check == 'IPACertMatchCheck'
+
+    @patch('ipalib.x509.load_certificate_list_from_file')
+    @patch('ipaserver.install.certs.CertDB')
+    def test_etc_cacert_mismatch(self, mock_certdb, mock_load_cert):
+        """ Test mismatch with /etc/ipa/ca.crt """
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        cacertentry = LDAPEntry(fake_conn,
+                                DN('cn=%s IPA CA' % m_api.env.realm,
+                                   'cn=certificates,cn=ipa,cn=etc',
+                                    m_api.env.basedn),
+                                CACertificate=[IPACertificate()])
+        trust = {
+            ('%s IPA CA' % m_api.env.realm): 'u,u,u'
+        }
+
+        mock_certdb.return_value = mock_CertDB(trust)
+        mock_load_cert.return_value = [IPACertificate(serial_number=2)]
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = IPACertMatchCheck(registry)
+        f.conn = mock_ldap([cacertentry])
+        self.results = capture_results(f)
+
+        assert len(self.results) == 3
+        result = self.results.results[0]
+        assert result.result == constants.ERROR
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPACertMatchCheck'
+
+    @patch('ipaserver.install.cainstance.CAInstance')
+    def test_cacert_caless(self, mock_cainstance):
+        """Nothing to check if the master is CALess"""
+
+        mock_cainstance.return_value = CAInstance(False)
+
+        framework = object()
+        registry.initialize(framework, config)
+        f = IPACertMatchCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 0
+
+
+class TestIPADogtagCertMatch(BaseTest):
+    patches = {
+        'ipaserver.install.krainstance.KRAInstance':
+        Mock(return_value=KRAInstance()),
+    }
+
+    @patch('ipaserver.install.certs.CertDB')
+    def test_certs_match_ok(self, mock_certdb):
+        """ Ensure match check is ok"""
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        pkidbentry = LDAPEntry(fake_conn,
+                               DN('uid=pkidbuser,ou=people,o=ipaca'),
+                               userCertificate=[IPACertificate()],
+                               subjectName=['test'])
+        casignentry = LDAPEntry(fake_conn,
+                                DN('cn=%s IPA CA' % m_api.env.realm,
+                                   'cn=certificates,cn=ipa,cn=etc',
+                                    m_api.env.basedn),
+                                CACertificate=[IPACertificate()],
+                                userCertificate=[IPACertificate()],
+                                subjectName=['test'])
+        ldap_entries = [pkidbentry, casignentry]
+        trust = {
+            'ocspSigningCert cert-pki-ca': 'u,u,u',
+            'caSigningCert cert-pki-ca': 'u,u,u',
+            'subsystemCert cert-pki-ca': 'u,u,u',
+            'auditSigningCert cert-pki-ca': 'u,u,Pu',
+            'Server-Cert cert-pki-ca': 'u,u,u',
+            'transportCert cert-pki-kra': 'u,u,u',
+            'storageCert cert-pki-kra': 'u,u,u',
+            'auditSigningCert cert-pki-kra': 'u,u,Pu',
+        }
+
+        dogtag_entries_subjects = (
+            'CN=OCSP Subsystem,O=%s' % m_api.env.realm,
+            'CN=CA Subsystem,O=%s' % m_api.env.realm,
+            'CN=CA Audit,O=%s' % m_api.env.realm,
+            'CN=%s,O=%s' % (m_api.env.host, m_api.env.realm),
+            'CN=KRA Transport Certificate,O=%s' % m_api.env.realm,
+            'CN=KRA Storage Certificate,O=%s' % m_api.env.realm,
+            'CN=KRA Audit,O=%s' % m_api.env.realm,
+        )
+
+        for i, subject in enumerate(dogtag_entries_subjects):
+            entry = LDAPEntry(fake_conn,
+                              DN('cn=%i,ou=certificateRepository' % i,
+                                 'ou=ca,o=ipaca'),
+                              userCertificate=[IPACertificate()],
+                              subjectName=[subject])
+            ldap_entries.append(entry)
+
+        mock_certdb.return_value = mock_CertDB(trust)
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = IPADogtagCertsMatchCheck(registry)
+        f.conn = mock_ldap(ldap_entries)
+        self.results = capture_results(f)
+
+        assert len(self.results) == 3
+        for result in self.results.results:
+            assert result.result == constants.SUCCESS
+            assert result.source == 'ipahealthcheck.ipa.certs'
+            assert result.check == 'IPADogtagCertsMatchCheck'
+
+    @patch('ipaserver.install.certs.CertDB')
+    def test_certs_mismatch(self, mock_certdb):
+        """ Ensure mismatches are detected"""
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        pkidbentry = LDAPEntry(fake_conn,
+                               DN('uid=pkidbuser,ou=people,o=ipaca'),
+                               userCertificate=[IPACertificate(
+                                   serial_number=2
+                               )],
+                               subjectName=['test'])
+        casignentry = LDAPEntry(fake_conn,
+                                DN('cn=%s IPA CA' % m_api.env.realm,
+                                   'cn=certificates,cn=ipa,cn=etc',
+                                    m_api.env.basedn),
+                                CACertificate=[IPACertificate()],
+                                userCertificate=[IPACertificate()],
+                                subjectName=['test'])
+        ldap_entries = [pkidbentry, casignentry]
+        trust = {
+            'ocspSigningCert cert-pki-ca': 'u,u,u',
+            'caSigningCert cert-pki-ca': 'u,u,u',
+            'subsystemCert cert-pki-ca': 'u,u,u',
+            'auditSigningCert cert-pki-ca': 'u,u,Pu',
+            'Server-Cert cert-pki-ca': 'u,u,u',
+            'transportCert cert-pki-kra': 'u,u,u',
+            'storageCert cert-pki-kra': 'u,u,u',
+            'auditSigningCert cert-pki-kra': 'u,u,Pu',
+        }
+
+        dogtag_entries_subjects = (
+            'CN=OCSP Subsystem,O=%s' % m_api.env.realm,
+            'CN=CA Subsystem,O=%s' % m_api.env.realm,
+            'CN=CA Audit,O=%s' % m_api.env.realm,
+            'CN=%s,O=%s' % (m_api.env.host, m_api.env.realm),
+            'CN=KRA Transport Certificate,O=%s' % m_api.env.realm,
+            'CN=KRA Storage Certificate,O=%s' % m_api.env.realm,
+            'CN=KRA Audit,O=%s' % m_api.env.realm,
+        )
+
+        for i, subject in enumerate(dogtag_entries_subjects):
+            entry = LDAPEntry(fake_conn,
+                              DN('cn=%i,ou=certificateRepository' % i,
+                                 'ou=ca,o=ipaca'),
+                              userCertificate=[IPACertificate()],
+                              subjectName=[subject])
+            ldap_entries.append(entry)
+
+        mock_certdb.return_value = mock_CertDB(trust)
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = IPADogtagCertsMatchCheck(registry)
+        f.conn = mock_ldap(ldap_entries)
+        self.results = capture_results(f)
+
+        assert len(self.results) == 3
+        result = self.results.results[0]
+        assert result.result == constants.ERROR
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPADogtagCertsMatchCheck'


### PR DESCRIPTION
Add checks to detect mismatch of certificates between LDAP
and NSS databases. Check for existance of entries as well as
ensure the certificates match between the different databases.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1886770
Signed-off-by: Antonio Torres <antorres@redhat.com>