### PR TITLE
Add dependencies so healthcheck returns sooner if 389-ds is down

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -81,6 +81,26 @@ def run_service_plugins(plugins, source, check):
         if not isinstance(plugin, ServiceCheck):
             continue
 
+        # Try to save some time to not check dependent services if the
+        # parent is down.
+        if not set(plugin.requires).issubset(available):
+            # A required service is not available. Either it hasn't been
+            # checked yet or it isn't running. If not running break.
+            running = True
+            for result in results.results:
+                if result.check in plugin.requires:
+                    # if not in available but in results the service failed
+                    running = False
+                    break
+            if not running:
+                logger.debug(
+                    'Skipping %s:%s because %s service(s) not running',
+                    plugin.__class__.__module__,
+                    plugin.__class__.__name__,
+                    ', '.join(set(plugin.requires) - set(available))
+                )
+                continue
+
         logger.debug('Calling check %s', plugin)
         for result in plugin.check():
             # always run the service checks so dependencies work

--- a/src/ipahealthcheck/ipa/host.py
+++ b/src/ipahealthcheck/ipa/host.py
@@ -23,7 +23,7 @@ logger = logging.getLogger()
 @registry
 class IPAHostKeytab(IPAPlugin):
     """Ensure the host keytab can get a TGT"""
-    requires = ('krb5kdc',)
+    requires = ('krb5kdc', 'dirsrv')
 
     @duration
     def check(self):

--- a/src/ipahealthcheck/meta/services.py
+++ b/src/ipahealthcheck/meta/services.py
@@ -92,6 +92,8 @@ class ipa_custodia(IPAServiceCheck):
 
 @registry
 class ipa_dnskeysyncd(IPAServiceCheck):
+    requires = ('dirsrv',)
+
     def check(self, instance=''):
         self.service_name = 'ipa-dnskeysyncd'
 


### PR DESCRIPTION
If dirsrv is down then not much works. Add a dependency to the IPAHostKeytab check and add dependency handling to the service checks.