### PR TITLE
Restore the log level after loading the resources

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -21,12 +21,15 @@ logger = logging.getLogger()
 
 
 def find_registries(entry_points):
+    # Loading the resources may reset the log level, save it.
+    log_level = logger.level
     registries = {}
     for entry_point in entry_points:
         registries.update({
             ep.name: ep.resolve()
             for ep in pkg_resources.iter_entry_points(entry_point)
         })
+    logger.setLevel(log_level)
     return registries
 
 


### PR DESCRIPTION
It seems that loading the resources can affect the log level so
save it off before loading them and then restore it.

I'm not entirely sure what is happening but this is an easy fix
and we can address it further later if we want.

Signed-off-by: Rob Crittenden <rcritten@redhat.com>