### PR TITLE
Don't report CA errors in an IPA CA-less installation

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -265,6 +265,13 @@ class RunChecks:
         if rval is not None:
             return rval
 
+        # If we have IPA configured without a CA then we want to skip
+        # the pkihealthcheck plugins otherwise they will generated a
+        # lot of false positives. The IPA plugins are loaded first so
+        # which should set ca_configured in its registry to True or
+        # False. We will skip the pkihealthcheck plugins only if
+        # ca_configured is False which means that it was set by IPA.
+        ca_configured = None
         for name, registry in find_registries(self.entry_points).items():
             try:
                 registry.initialize(framework, config, options)
@@ -276,6 +283,11 @@ class RunChecks:
                 except Exception as e:
                     logger.error("Unable to initialize %s: %s", name, e)
                     continue
+            if hasattr(registry, 'ca_configured'):
+                ca_configured = registry.ca_configured
+            if 'pkihealthcheck' in name and ca_configured is False:
+                logger.debug('IPA CA is not configured, skipping %s', name)
+                continue
             for plugin in find_plugins(name, registry):
                 plugins.append(plugin)
 

--- a/src/ipahealthcheck/ipa/plugin.py
+++ b/src/ipahealthcheck/ipa/plugin.py
@@ -34,6 +34,7 @@ class IPARegistry(Registry):
         super().__init__()
         self.trust_agent = False
         self.trust_controller = False
+        self.ca_configured = False
 
     def initialize(self, framework, config, options=None):
         super().initialize(framework, config)
@@ -84,6 +85,9 @@ class IPARegistry(Registry):
         role = roles[1].status(api)[0]
         if role.get('status') == 'enabled':
             self.trust_controller = True
+
+        ca = cainstance.CAInstance(api.env.realm, host_name=api.env.host)
+        self.ca_configured = ca.is_configured()
 
 
 registry = IPARegistry()

--- a/src/ipahealthcheck/ipa/roles.py
+++ b/src/ipahealthcheck/ipa/roles.py
@@ -25,6 +25,8 @@ class IPACRLManagerCheck(IPAPlugin):
     """
     @duration
     def check(self):
+        if not self.ca.is_configured():
+            return
         try:
             enabled = self.ca.is_crlgen_enabled()
         except AttributeError:

--- a/tests/test_ipa_roles.py
+++ b/tests/test_ipa_roles.py
@@ -48,6 +48,18 @@ class TestCRLManagerRole(BaseTest):
         assert result.check == 'IPACRLManagerCheck'
         assert result.kw.get('crlgen_enabled') is True
 
+    @patch('ipaserver.install.cainstance.CAInstance')
+    def test_crlmanager_no_ca(self, mock_ca):
+        """There should be no CRLManagerCheck without a CA"""
+        mock_ca.return_value = CAInstance(False)
+        framework = object()
+        registry.initialize(framework, config.Config)
+        f = IPACRLManagerCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 0
+
 
 class TestRenewalMaster(BaseTest):
     def test_renewal_master_not_set(self):


### PR DESCRIPTION
The role checker was reporting CRL manager status. This isn't available in a CA-less install.

The pki healthcheck checks were all returning the same missing pki-tomcat instance error.