### PR TITLE
Add a --version cli option

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -157,6 +157,8 @@ def add_default_options(parser, output_registry, default_output):
                         default=default_output, help='Output method')
     parser.add_argument('--output-file', dest='outfile', default=None,
                         help='File to store output')
+    parser.add_argument('--version', dest='version', action='store_true',
+                        help='Report the version number and exit')
 
 
 def add_output_options(parser, output_registry):
@@ -242,6 +244,16 @@ class RunChecks:
         self.add_options()
         options = parse_options(self.parser)
         self.options = options
+
+        if options.version:
+            for registry in self.entry_points:
+                name = registry.split('.')[0]
+                try:
+                    version = pkg_resources.get_distribution(name).version
+                except pkg_resources.DistributionNotFound:
+                    continue
+                print('%s: %s' % (name, version))
+            return 0
 
         # pylint: disable=assignment-from-none
         rval = self.validate_options()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,15 @@
+#
+# Copyright (C) 2021 FreeIPA Contributors see COPYING for license
+#
+
+import os
+
+from ipapython.ipautil import run
+
+
+def test_version():
+    """
+    Test the --version option
+    """
+    output = run(['ipa-healthcheck', '--version'], env=os.environ)
+    assert 'ipahealthcheck' in output.raw_output.decode('utf-8')


### PR DESCRIPTION
I chose the pkg_resources method since it seemed the most
straightforward. It also gave me an excuse to configure
install_requires in setup.py. This works for me in a
development environment in Fedora anyway.

https://github.com/freeipa/freeipa-healthcheck/issues/189

Signed-off-by: Rob Crittenden <rcritten@redhat.com>