### PR TITLE
Replace or drop print() statements

### DIFF
--- a/src/ipahealthcheck/dogtag/ca.py
+++ b/src/ipahealthcheck/dogtag/ca.py
@@ -53,14 +53,14 @@ class DogtagCertsConfigCheck(DogtagPlugin):
         db = certs.CertDB(api.env.realm, paths.PKI_TOMCAT_ALIAS_DIR)
         for nickname, _trust_flags in db.list_certs():
             if nickname in skip:
-                logging.debug('Skipping nickname %s because it isn\'t in '
-                              'the configuration file')
+                logger.debug('Skipping nickname %s because it isn\'t in '
+                             'the configuration file')
                 continue
             try:
                 val = get_directive(paths.CA_CS_CFG_PATH,
                                     blobs[nickname], '=')
             except KeyError:
-                print("%s not found, assuming 3rd party" % nickname)
+                logger.debug("%s not found, assuming 3rd party", nickname)
                 continue
             if val is None:
                 yield Result(self, constants.ERROR,

--- a/src/ipahealthcheck/ipa/plugin.py
+++ b/src/ipahealthcheck/ipa/plugin.py
@@ -15,8 +15,7 @@ from ipaserver.install import installutils
 
 from ipahealthcheck.core.plugin import Plugin, Registry
 
-
-logging.getLogger()
+logger = logging.getLogger()
 
 
 class IPAPlugin(Plugin):
@@ -56,7 +55,7 @@ class IPARegistry(Registry):
             try:
                 api.Backend.ldap2.connect()
             except (errors.CCacheError, errors.NetworkError) as e:
-                logging.debug('Failed to connect to LDAP: %s', e)
+                logger.debug('Failed to connect to LDAP: %s', e)
             return
 
         # This package is pulled in when the trust package is installed

--- a/tests/test_ipa_trust.py
+++ b/tests/test_ipa_trust.py
@@ -409,7 +409,6 @@ class TestIPADomain(BaseTest):
 
         self.results = capture_results(f)
 
-        print(self.results.results)
         assert len(self.results) == 1
 
         result = self.results.results[0]


### PR DESCRIPTION
The print in dogtag/ca.py was supposed to be a debug statement.
Converted it to use logger and fixed a related issue that was
calling logging.debug instead of logger.debug.

Drop a print() statement from a test, probably leftover from
troubleshooting a failure.

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

https://github.com/freeipa/freeipa-healthcheck/issues/207