### PR TITLE
Handle files that don't exist in FileCheck

### DIFF
--- a/src/ipahealthcheck/core/files.py
+++ b/src/ipahealthcheck/core/files.py
@@ -33,6 +33,13 @@ class FileCheck:
                 owner = tuple((owner,))
             if not isinstance(group, tuple):
                 group = tuple((group,))
+            if not os.path.exists(path):
+                for type in ('mode', 'owner', 'group'):
+                    key = '%s_%s' % (path.replace('/', '_'), type)
+                    yield Result(self, constants.SUCCESS, key=key,
+                                 type=type, path=path,
+                                 msg='File does not exist')
+                continue
             stat = os.stat(path)
             fmode = str(oct(stat.st_mode)[-4:])
             key = '%s_mode' % path.replace('/', '_')

--- a/tests/test_core_files.py
+++ b/tests/test_core_files.py
@@ -144,3 +144,20 @@ def test_files_mode(mock_stat):
     my_results = get_results(results, 'mode')
     assert my_results.results[0].result == constants.WARNING
     assert my_results.results[1].result == constants.WARNING
+
+
+@patch('os.path.exists')
+def test_files_not_found(mock_exists):
+    mock_exists.return_value = False
+
+    f = FileCheck()
+    f.files = files
+
+    results = capture_results(f)
+
+    for type in ('mode', 'group', 'owner'):
+        my_results = get_results(results, type)
+        assert len(my_results.results) == 4
+        for result in my_results.results:
+            assert result.result == constants.SUCCESS
+            assert result.kw.get('msg') == 'File does not exist'


### PR DESCRIPTION
A raw os.stat() was called which could raise an exception if the file
doesn't exist. Instead call os.path.exists() and if the result is False
then raise a SUCCESS with a message that the file doesn't exist.

https://github.com/freeipa/freeipa-healthcheck/issues/213

Signed-off-by: Rob Crittenden <rcritten@redhat.com>