### PR TITLE
Fix some deprecation issues, add support for DNS URI records

### DIFF
--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -1,30 +1,510 @@
-""" Plugin to teach Pylint about FreeIPA API
-"""
+#
+# Copyright (C) 2015  FreeIPA Contributors see COPYING for license
+#
 
+from __future__ import print_function
+
+import copy
+import os.path
+import sys
 import textwrap
 
 from astroid import MANAGER, register_module_extender
+from astroid import scoped_nodes
+from pylint.checkers import BaseChecker
+from pylint.checkers.utils import check_messages
+from pylint.interfaces import IAstroidChecker
 from astroid.builder import AstroidBuilder
 
 
 def register(linter):
-    pass
+    linter.register_checker(IPAChecker(linter))
 
 
-AstroidBuilder(MANAGER).string_build(
-    textwrap.dedent(
-        """
+def _warning_already_exists(cls, member):
+    print(
+        "WARNING: member '{member}' in '{cls}' already exists".format(
+            cls="{}.{}".format(cls.root().name, cls.name), member=member),
+        file=sys.stderr
+    )
+
+
+def fake_class(name_or_class_obj, members=()):
+    if isinstance(name_or_class_obj, scoped_nodes.ClassDef):
+        cl = name_or_class_obj
+    else:
+        cl = scoped_nodes.ClassDef(name_or_class_obj, None)
+
+    for m in members:
+        if isinstance(m, str):
+            if m in cl.locals:
+                _warning_already_exists(cl, m)
+            else:
+                cl.locals[m] = [scoped_nodes.ClassDef(m, None)]
+        elif isinstance(m, dict):
+            for key, val in m.items():
+                assert isinstance(key, str), "key must be string"
+                if key in cl.locals:
+                    _warning_already_exists(cl, key)
+                    fake_class(cl.locals[key], val)
+                else:
+                    cl.locals[key] = [fake_class(key, val)]
+        else:
+            # here can be used any astroid type
+            if m.name in cl.locals:
+                _warning_already_exists(cl, m.name)
+            else:
+                cl.locals[m.name] = [copy.copy(m)]
+    return cl
+
+
+# 'class': ['generated', 'properties']
+ipa_class_members = {
+    # Python standard library & 3rd party classes
+    'socket._socketobject': ['sendall'],
+
+    # IPA classes
+    'ipalib.base.NameSpace': [
+        'add',
+        'mod',
+        'del',
+        'show',
+        'find'
+    ],
+    'ipalib.cli.Collector': ['__options'],
+    'ipalib.config.Env': [  # somehow needed for pylint on Python 2
+        'debug',
+        'startup_traceback',
+        'server',
+        'validate_api',
+        'verbose',
+    ],
+    'ipalib.errors.ACIError': [
+        'info',
+    ],
+    'ipalib.errors.ConversionError': [
+        'error',
+    ],
+    'ipalib.errors.DatabaseError': [
+        'desc',
+    ],
+    'ipalib.errors.NetworkError': [
+        'error',
+    ],
+    'ipalib.errors.NotFound': [
+        'reason',
+    ],
+    'ipalib.errors.PublicError': [
+        'msg',
+        'strerror',
+        'kw',
+    ],
+    'ipalib.errors.SingleMatchExpected': [
+        'found',
+    ],
+    'ipalib.errors.SkipPluginModule': [
+        'reason',
+    ],
+    'ipalib.errors.ValidationError': [
+        'error',
+    ],
+    'ipalib.errors.SchemaUpToDate': [
+        'fingerprint',
+        'ttl',
+    ],
+    'ipalib.messages.PublicMessage': [
+        'msg',
+        'strerror',
+        'type',
+        'kw',
+    ],
+    'ipalib.parameters.Param': [
+        'cli_name',
+        'cli_short_name',
+        'label',
+        'default',
+        'doc',
+        'required',
+        'multivalue',
+        'primary_key',
+        'normalizer',
+        'default_from',
+        'autofill',
+        'query',
+        'attribute',
+        'include',
+        'exclude',
+        'flags',
+        'hint',
+        'alwaysask',
+        'sortorder',
+        'option_group',
+        'no_convert',
+        'deprecated',
+     ],
+    'ipalib.parameters.Bool': [
+        'truths',
+        'falsehoods'],
+    'ipalib.parameters.Data': [
+        'minlength',
+        'maxlength',
+        'length',
+        'pattern',
+        'pattern_errmsg',
+    ],
+    'ipalib.parameters.Str': ['noextrawhitespace'],
+    'ipalib.parameters.Password': ['confirm'],
+    'ipalib.parameters.File': ['stdin_if_missing'],
+    'ipalib.parameters.Enum': ['values'],
+    'ipalib.parameters.Number': [
+        'minvalue',
+        'maxvalue',
+    ],
+    'ipalib.parameters.Decimal': [
+        'precision',
+        'exponential',
+        'numberclass',
+    ],
+    'ipalib.parameters.DNSNameParam': [
+        'only_absolute',
+        'only_relative',
+    ],
+    'ipalib.parameters.Principal': [
+        'require_service',
+    ],
+    'ipalib.plugable.API': [
+        'Advice',
+    ],
+    'ipalib.util.ForwarderValidationError': [
+        'msg',
+    ],
+    'ipaserver.plugins.dns.DNSRecord': [
+        'validatedns',
+        'normalizedns',
+    ],
+}
+
+
+def fix_ipa_classes(cls):
+    class_name_with_module = "{}.{}".format(cls.root().name, cls.name)
+    if class_name_with_module in ipa_class_members:
+        fake_class(cls, ipa_class_members[class_name_with_module])
+
+
+MANAGER.register_transform(scoped_nodes.ClassDef, fix_ipa_classes)
+
+
+def ipaplatform_constants_transform():
+    return AstroidBuilder(MANAGER).string_build(textwrap.dedent('''
+    from ipaplatform.base.constants import constants, User, Group
+    __all__ = ('constants', 'User', 'Group')
+    '''))
+
+
+def ipaplatform_paths_transform():
+    return AstroidBuilder(MANAGER).string_build(textwrap.dedent('''
+    from ipaplatform.base.paths import paths
+    __all__ = ('paths',)
+    '''))
+
+
+def ipaplatform_services_transform():
+    return AstroidBuilder(MANAGER).string_build(textwrap.dedent('''
+    from ipaplatform.base.services import knownservices
+    from ipaplatform.base.services import timedate_services
+    from ipaplatform.base.services import service
+    from ipaplatform.base.services import wellknownservices
+    from ipaplatform.base.services import wellknownports
+    __all__ = ('knownservices', 'timedate_services', 'service',
+               'wellknownservices', 'wellknownports')
+    '''))
+
+
+def ipaplatform_tasks_transform():
+    return AstroidBuilder(MANAGER).string_build(textwrap.dedent('''
+    from ipaplatform.base.tasks import tasks
+    __all__ = ('tasks',)
+    '''))
+
+
+register_module_extender(MANAGER, 'ipaplatform.constants',
+                         ipaplatform_constants_transform)
+register_module_extender(MANAGER, 'ipaplatform.paths',
+                         ipaplatform_paths_transform)
+register_module_extender(MANAGER, 'ipaplatform.services',
+                         ipaplatform_services_transform)
+register_module_extender(MANAGER, 'ipaplatform.tasks',
+                         ipaplatform_tasks_transform)
+
+
+def ipalib_request_transform():
+    """ipalib.request.context attribute
+    """
+    return AstroidBuilder(MANAGER).string_build(textwrap.dedent('''
+    from ipalib.request import context
+    context._pylint_attr = Connection("_pylint", lambda: None)
+    '''))
+
+
+register_module_extender(MANAGER, 'ipalib.request', ipalib_request_transform)
+
+
+class IPAChecker(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = 'ipa'
+    msgs = {
+        'W9901': (
+            'Forbidden import %s (can\'t import from %s in %s)',
+            'ipa-forbidden-import',
+            'Used when an forbidden import is detected.',
+        ),
+    }
+    options = (
+        (
+            'forbidden-imports',
+            {
+                'default': '',
+                'type': 'csv',
+                'metavar': '<path>[:<module>[:<module>...]][,<path>...]',
+                'help': 'Modules which are forbidden to be imported in the '
+                        'given paths',
+            },
+        ),
+    )
+    priority = -1
+
+    def open(self):
+        self._dir = os.path.abspath(os.path.dirname(__file__))
+
+        self._forbidden_imports = {self._dir: []}
+        for forbidden_import in self.config.forbidden_imports:
+            forbidden_import = forbidden_import.split(':')
+            path = os.path.join(self._dir, forbidden_import[0])
+            path = os.path.abspath(path)
+            modules = forbidden_import[1:]
+            self._forbidden_imports[path] = modules
+
+        self._forbidden_imports_stack = []
+
+    def _get_forbidden_import_rule(self, node):
+        path = node.path
+        if path and isinstance(path, list):
+            # In pylint 2.0, path is a list with one element. Namespace
+            # packages may contain more than one element, but we can safely
+            # ignore them, as they don't contain code.
+            path = path[0]
+        if path:
+            path = os.path.abspath(path)
+            while path.startswith(self._dir):
+                if path in self._forbidden_imports:
+                    return path
+                path = os.path.dirname(path)
+        return self._dir
+
+    def visit_module(self, node):
+        self._forbidden_imports_stack.append(
+            self._get_forbidden_import_rule(node))
+
+    def leave_module(self, node):
+        self._forbidden_imports_stack.pop()
+
+    def _check_forbidden_imports(self, node, names):
+        path = self._forbidden_imports_stack[-1]
+        relpath = os.path.relpath(path, self._dir)
+        modules = self._forbidden_imports[path]
+        for module in modules:
+            module_prefix = module + '.'
+            for name in names:
+                if name == module or name.startswith(module_prefix):
+                    self.add_message('ipa-forbidden-import',
+                                     args=(name, module, relpath), node=node)
+
+    @check_messages('ipa-forbidden-import')
+    def visit_import(self, node):
+        names = [n[0] for n in node.names]
+        self._check_forbidden_imports(node, names)
+
+    @check_messages('ipa-forbidden-import')
+    def visit_importfrom(self, node):
+        names = ['{}.{}'.format(node.modname, n[0]) for n in node.names]
+        self._check_forbidden_imports(node, names)
+
+
+#
+# Teach pylint how api object works
+#
+# ipalib uses some tricks to create api.env members and api objects. pylint
+# is not able to infer member names and types from code. The explict
+# assignments inside the string builder templates are good enough to show
+# pylint, how the api is created. Additional transformations are not
+# required.
+#
+
+AstroidBuilder(MANAGER).string_build(textwrap.dedent(
+    """
     from ipalib import api
-    from ipalib import plugable
+    from ipalib import cli, plugable, rpc
+    from ipalib.base import NameSpace
+    from ipaclient.plugins import rpcclient
+    try:
+        from ipaserver.plugins import dogtag, ldap2, serverroles
+    except ImportError:
+        HAS_SERVER = False
+    else:
+        HAS_SERVER = True
 
+    def wildcard(*args, **kwargs):
+        return None
+
+    # ipalib.api members
     api.Backend = plugable.APINameSpace(api, None)
     api.Command = plugable.APINameSpace(api, None)
+    api.Method = plugable.APINameSpace(api, None)
+    api.Object = plugable.APINameSpace(api, None)
+    api.Updater = plugable.APINameSpace(api, None)
+    # ipalib.api.Backend members
+    api.Backend.cli = cli.cli(api)
+    api.Backend.textui = cli.textui(api)
+    api.Backend.jsonclient = rpc.jsonclient(api)
+    api.Backend.rpcclient = rpcclient.rpcclient(api)
+    api.Backend.xmlclient = rpc.xmlclient(api)
+
+    if HAS_SERVER:
+        api.Backend.kra = dogtag.kra(api)
+        api.Backend.ldap2 = ldap2.ldap2(api)
+        api.Backend.ra = dogtag.ra(api)
+        api.Backend.ra_certprofile = dogtag.ra_certprofile(api)
+        api.Backend.ra_lightweight_ca = dogtag.ra_lightweight_ca(api)
+        api.Backend.serverroles = serverroles.serverroles(api)
+
+    # ipalib.base.NameSpace
+    NameSpace.find = wildcard
     """
-    )
-)
+))
 
 
-# dnspython 2.x RR types
+AstroidBuilder(MANAGER).string_build(textwrap.dedent(
+    """
+    from ipalib import api
+    from ipapython.dn import DN
+
+    api.env.api_version = ''
+    api.env.bin = ''  # object
+    api.env.ca_agent_port = 0
+    api.env.ca_host = ''
+    api.env.ca_install_port = None
+    api.env.ca_port = 0
+    api.env.certmonger_wait_timeout = 0
+    api.env.conf = ''  # object
+    api.env.conf_default = ''  # object
+    api.env.confdir = ''  # object
+    api.env.container_accounts = DN()
+    api.env.container_adtrusts = DN()
+    api.env.container_applications = DN()
+    api.env.container_automember = DN()
+    api.env.container_automount = DN()
+    api.env.container_ca = DN()
+    api.env.container_ca_renewal = DN()
+    api.env.container_caacl = DN()
+    api.env.container_certmap = DN()
+    api.env.container_certmaprules = DN()
+    api.env.container_certprofile = DN()
+    api.env.container_cifsdomains = DN()
+    api.env.container_configs = DN()
+    api.env.container_custodia = DN()
+    api.env.container_deleteuser = DN()
+    api.env.container_dna = DN()
+    api.env.container_dna_posix_ids = DN()
+    api.env.container_dns = DN()
+    api.env.container_dnsservers = DN()
+    api.env.container_group = DN()
+    api.env.container_hbac = DN()
+    api.env.container_hbacservice = DN()
+    api.env.container_hbacservicegroup = DN()
+    api.env.container_host = DN()
+    api.env.container_hostgroup = DN()
+    api.env.container_locations = DN()
+    api.env.container_masters = DN()
+    api.env.container_netgroup = DN()
+    api.env.container_otp = DN()
+    api.env.container_permission = DN()
+    api.env.container_policies = DN()
+    api.env.container_policygroups = DN()
+    api.env.container_policylinks = DN()
+    api.env.container_privilege = DN()
+    api.env.container_radiusproxy = DN()
+    api.env.container_ranges = DN()
+    api.env.container_realm_domains = DN()
+    api.env.container_rolegroup = DN()
+    api.env.container_roles = DN()
+    api.env.container_s4u2proxy = DN()
+    api.env.container_selinux = DN()
+    api.env.container_service = DN()
+    api.env.container_stageuser = DN()
+    api.env.container_sudocmd = DN()
+    api.env.container_sudocmdgroup = DN()
+    api.env.container_sudorule = DN()
+    api.env.container_sysaccounts = DN()
+    api.env.container_topology = DN()
+    api.env.container_trusts = DN()
+    api.env.container_user = DN()
+    api.env.container_vault = DN()
+    api.env.container_views = DN()
+    api.env.container_virtual = DN()
+    api.env.context = ''  # object
+    api.env.debug = False
+    api.env.delegate = False
+    api.env.dogtag_version = 0
+    api.env.dot_ipa = ''  # object
+    api.env.enable_ra = False
+    api.env.env_confdir = None
+    api.env.fallback = True
+    api.env.force_schema_check = False
+    api.env.home = ''  # object
+    api.env.host = ''
+    api.env.host_princ = ''
+    api.env.http_timeout = 0
+    api.env.in_server = False  # object
+    api.env.in_tree = False  # object
+    api.env.interactive = True
+    api.env.ipalib = ''  # object
+    api.env.kinit_lifetime = None
+    api.env.lite_pem = ''
+    api.env.lite_profiler = ''
+    api.env.lite_host = ''
+    api.env.lite_port = 0
+    api.env.log = ''  # object
+    api.env.logdir = ''  # object
+    api.env.mode = ''
+    api.env.mount_ipa = ''
+    api.env.nss_dir = ''  # object
+    api.env.plugins_on_demand = False  # object
+    api.env.prompt_all = False
+    api.env.ra_plugin = ''
+    api.env.recommended_max_agmts = 0
+    api.env.replication_wait_timeout = 0
+    api.env.rpc_protocol = ''
+    api.env.server = ''
+    api.env.script = ''  # object
+    api.env.site_packages = ''  # object
+    api.env.skip_version_check = False
+    api.env.smb_princ = ''
+    api.env.startup_timeout = 0
+    api.env.startup_traceback = False
+    api.env.tls_ca_cert = ''  # object
+    api.env.tls_version_max = ''
+    api.env.tls_version_min = ''
+    api.env.validate_api = False
+    api.env.verbose = 0
+    api.env.version = ''
+    api.env.wait_for_dns = 0
+    api.env.webui_prod = True
+    """
+))
+
+# dnspython 2.x introduces enums and creates module level globals from them
+# pylint does not understand the trick
 AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     """
     import dns.flags
@@ -53,35 +533,40 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     """
 ))
 
-
-def ipaplatform_paths_transform():
-    return AstroidBuilder(MANAGER).string_build(textwrap.dedent('''
-    from ipaplatform.base.paths import paths
-    __all__ = ('paths',)
-    '''))
-
-
-def ipaplatform_services_transform():
-    return AstroidBuilder(MANAGER).string_build(textwrap.dedent('''
-    from ipaplatform.base.services import knownservices
-    from ipaplatform.base.services import timedate_services
-    from ipaplatform.base.services import service
-    from ipaplatform.base.services import wellknownservices
-    from ipaplatform.base.services import wellknownports
-    __all__ = ('knownservices', 'timedate_services', 'service',
-               'wellknownservices', 'wellknownports')
-    '''))
+AstroidBuilder(MANAGER).string_build(
+    textwrap.dedent(
+        """\
+    from ipatests.test_integration.base import IntegrationTest
+    from ipatests.pytest_ipa.integration.host import Host, WinHost
+    from ipatests.pytest_ipa.integration.config import Config, Domain
 
 
-def ipaplatform_constants_transform():
-    return AstroidBuilder(MANAGER).string_build(textwrap.dedent('''
-    from ipaplatform.base.constants import constants
-    __all__ = ('constants',)
-    '''))
+    class PylintIPAHosts:
+        def __getitem__(self, key):
+            return Host()
 
-register_module_extender(MANAGER, 'ipaplatform.paths',
-                         ipaplatform_paths_transform)
-register_module_extender(MANAGER, 'ipaplatform.services',
-                         ipaplatform_services_transform)
-register_module_extender(MANAGER, 'ipaplatform.constants',
-                         ipaplatform_constants_transform)
+
+    class PylintWinHosts:
+        def __getitem__(self, key):
+            return WinHost()
+
+
+    class PylintADDomains:
+        def __getitem__(self, key):
+            return Domain()
+
+
+    Host.config = Config()
+    Host.domain = Domain()
+
+    IntegrationTest.domain = Domain()
+    IntegrationTest.master = Host()
+    IntegrationTest.replicas = PylintIPAHosts()
+    IntegrationTest.clients = PylintIPAHosts()
+    IntegrationTest.ads = PylintWinHosts()
+    IntegrationTest.ad_treedomains = PylintWinHosts()
+    IntegrationTest.ad_subdomains = PylintWinHosts()
+    IntegrationTest.ad_domains = PylintADDomains()
+    """
+    )
+)

--- a/pylintrc
+++ b/pylintrc
@@ -1,51 +1,142 @@
 [MASTER]
+# Pickle collected data for later comparisons.
 persistent=no
 
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+# FIXME: has to be specified on the command line otherwise pylint fails with
+#        DuplicateSectionError for the IPA section
+#load-plugins=pylint_plugins
+
+# Use multiple processes to speed up Pylint.
+jobs=0
+
+# A list of packages with safe C extensions to load
 extension-pkg-whitelist=
     _ldap,
+    cryptography,
+    gssapi,
+    netifaces
+
+[CLASSES]
+
+# List of valid names for the first argument in a metaclass class method.
+# This can be removed after upgrading to pylint 2.0
+valid-metaclass-classmethod-first-arg=cls
 
 [MESSAGES CONTROL]
+
 enable=
     all,
-    python3,
+    python3
 
 disable=
     I,
-    bad-continuation,
-    bad-indentation,
-    bad-whitespace,
-    broad-except,
-    dangerous-default-value,
     duplicate-code,
-    fixme,
-    global-statement,
-    invalid-name,
-    line-too-long,
-    missing-docstring,
-    no-absolute-import,
+    interface-not-implemented,
     no-self-use,
-    protected-access,
-    raise-missing-from,
-    redefined-builtin,
-    redefined-outer-name,
-    super-init-not-called,
-    superfluous-parens,
+    redefined-variable-type,
     too-few-public-methods,
+    too-many-ancestors,
     too-many-arguments,
+    too-many-boolean-expressions,
     too-many-branches,
     too-many-instance-attributes,
-    too-many-lines,
     too-many-locals,
     too-many-nested-blocks,
     too-many-public-methods,
     too-many-return-statements,
     too-many-statements,
-    trailing-newlines,
-    trailing-whitespace,
-    ungrouped-imports,
+    abstract-method,
+    anomalous-backslash-in-string,
+    arguments-differ,
+    attribute-defined-outside-init,
+    bad-builtin,
+    bad-indentation,
+    broad-except,
+    consider-using-dict-items,
+    dangerous-default-value,
+    eval-used,
+    exec-used,
+    fixme,
+    global-statement,
+    no-init,
+    pointless-string-statement,
+    protected-access,
+    redefined-builtin,
+    redefined-outer-name,
+    super-init-not-called,
+    undefined-loop-variable,
+    unnecessary-lambda,
     unused-argument,
+    useless-else-on-loop,
+    bad-continuation,
+    bad-whitespace,
+    blacklisted-name,
+    invalid-name,
+    line-too-long,
+    missing-docstring,
+    multiple-statements,
+    superfluous-parens,
+    too-many-lines,
+    unidiomatic-typecheck,
+    no-absolute-import,
     wrong-import-order,
+    ungrouped-imports,
     wrong-import-position,
+    unsubscriptable-object,
+    unsupported-membership-test,
+    not-an-iterable,
+    singleton-comparison,
+    misplaced-comparison-constant,
+    not-a-mapping,
+    singleton-comparison,
+    len-as-condition,  # new in pylint 1.7
+    no-else-return,  # new in pylint 1.7
+    single-string-used-for-slots,  # new in pylint 1.7
+    useless-super-delegation,  # new in pylint 1.7
+    redefined-argument-from-local,  # new in pylint 1.7
+    consider-merging-isinstance,  # new in pylint 1.7
+    bad-option-value,  # required to support upgrade to pylint 2.0
+    assignment-from-no-return,  # new in pylint 2.0
+    keyword-arg-before-vararg,  # pylint 2.0, remove after dropping Python 2
+    consider-using-enumerate,  # pylint 2.1, clean up tests later
+    no-else-raise, # python 2.4.0
+    import-outside-toplevel, # pylint 2.4.2
+    f-string-without-interpolation,  # pylint 2.5.0, bare f-strings are ok
+    super-with-arguments,  # pylint 2.6.0, zero-length form is syntactic sugar
+    raise-missing-from,  # pylint 2.6.0, implicit exception chaining is ok
+    consider-using-with,  # pylint 2.8.0, contextmanager is not mandatory
+    consider-using-max-builtin,  # pylint 2.8.0, can be more readable
+    consider-using-min-builtin,  # pylint 2.8.0, can be more readable
 
 [REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
 output-format=colorized
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg})'
+
+
+[VARIABLES]
+dummy-variables-rgx=(_.+|unused)
+
+
+[IPA]
+forbidden-imports=
+    client/:ipaserver,
+    ipaclient/:ipaclient.install:ipalib.install:ipaserver,
+    ipaclient/install/:ipaserver,
+    ipalib/:ipaclient.install:ipalib.install:ipaserver,
+    ipalib/install/:ipaserver,
+    ipaplatform/:ipaclient:ipalib:ipaserver,
+    ipapython/:ipaclient:ipalib:ipaserver
+    ipatests/pytest_ipa:ipaserver:ipaclient.install:ipalib.install
+    ipatests/test_integration:ipaserver

--- a/src/ipaclustercheck/core/output.py
+++ b/src/ipaclustercheck/core/output.py
@@ -60,7 +60,7 @@ class Ansible(ClusterOutput):
 
             rval = {'%s' % name: value}
             output.append(rval)
-            
+
         output = json.dumps(output, indent=self.indent)
         if self.filename is None:
             output += '\n'

--- a/src/ipaclustercheck/ipa/plugin.py
+++ b/src/ipaclustercheck/ipa/plugin.py
@@ -52,7 +52,7 @@ def get_masters(data):
 
         masters = output[0].get('kw').get('masters')
         if masters:
-            return masters          
+            return masters
 
     raise ValueError('Unable to determine full list of masters. '
                      'None of ipahealthcheck.ipa.meta:IPAMetaCheck '
@@ -97,7 +97,7 @@ class ClusterRegistry(Registry):
             except Exception as e:
                 logger.error("Unable to read %s: %s", fname, e)
                 continue
-        
+
             try:
                 data = json.loads(data)
             except Exception as e:
@@ -112,6 +112,6 @@ class ClusterRegistry(Registry):
             else:
                 logger.error("No fqdn defined in JSON in %s", fname)
                 continue
-        
-        
+
+
 registry = ClusterRegistry()

--- a/src/ipaclustercheck/ipa/ruv.py
+++ b/src/ipaclustercheck/ipa/ruv.py
@@ -123,7 +123,7 @@ class ClusterRUVCheck(ClusterPlugin):
         clean_csruvs = set()
         clean_ruvs = set()
         if dangles:
-            for _, master_info in info.items():
+            for _unused, master_info in info.items():
                 for ruv in master_info['clean_ruv']:
                     logger.debug(
                         "Dangling RUV id: %s, hostname: %s", ruv[1], ruv[0]

--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -8,8 +8,7 @@ import sys
 from ipahealthcheck.core import constants
 from ipahealthcheck.core.core import RunChecks
 
-
-from ipaserver.install.installutils import is_ipa_configured
+from ipalib.facts import is_ipa_configured
 
 
 class IPAChecks(RunChecks):

--- a/src/ipahealthcheck/dogtag/ca.py
+++ b/src/ipahealthcheck/dogtag/ca.py
@@ -41,7 +41,7 @@ class DogtagCertsConfigCheck(DogtagPlugin):
         # Nicknames to skip because their certs are not in CS.cfg
         skip = []
 
-        if kra.is_installed:
+        if kra.is_installed():
             kra_blobs = {
                 'transportCert cert-pki-kra':
                 'ca.connector.KRA.transportCert',

--- a/src/ipahealthcheck/ipa/idns.py
+++ b/src/ipahealthcheck/ipa/idns.py
@@ -11,7 +11,11 @@ from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.core import constants
 
 from ipalib import api
-from dns import resolver
+
+try:
+    from dns.resolver import resolve
+except ImportError:
+    from dns.resolver import query as resolve
 
 
 logger = logging.getLogger()
@@ -66,7 +70,7 @@ class IPADNSSystemRecordsCheck(IPAPlugin):
                     elif rd.rdtype == rdatatype.AAAA:
                         aaaa_rec.append(rd.to_text())
                     else:
-                        logger.error("Unhandler rdtype %d", rd.rdtype)
+                        logger.error("Unhandled rdtype %d", rd.rdtype)
 
         # For each SRV record that IPA thinks it should have, do a DNS
         # lookup of it and ensure that DNS has the same set of values
@@ -100,7 +104,7 @@ class IPADNSSystemRecordsCheck(IPAPlugin):
         for txt in txt_rec:
             logger.debug("Search DNS for TXT record of %s", txt)
             try:
-                answers = resolver.query(txt, rdatatype.TXT)
+                answers = resolve(txt, rdatatype.TXT)
             except DNSException as e:
                 logger.debug("DNS record not found: %s", e.__class__.__name__)
                 answers = []
@@ -123,7 +127,7 @@ class IPADNSSystemRecordsCheck(IPAPlugin):
             qname = "ipa-ca." + api.env.domain + "."
             logger.debug("Search DNS for A record of %s", qname)
             try:
-                answers = resolver.query(qname, rdatatype.A)
+                answers = resolve(qname, rdatatype.A)
             except DNSException as e:
                 logger.debug("DNS record not found: %s", e.__class__.__name__)
                 answers = []
@@ -157,7 +161,7 @@ class IPADNSSystemRecordsCheck(IPAPlugin):
             qname = "ipa-ca." + api.env.domain + "."
             logger.debug("Search DNS for AAAA record of %s", qname)
             try:
-                answers = resolver.query(qname, rdatatype.AAAA)
+                answers = resolve(qname, rdatatype.AAAA)
             except DNSException as e:
                 logger.debug("DNS record not found: %s", e.__class__.__name__)
                 answers = []

--- a/tests/test_ipa_dns.py
+++ b/tests/test_ipa_dns.py
@@ -48,7 +48,7 @@ else:
 
 def add_srv_records(qname, port_map, priority=0, weight=100):
     rdlist = []
-    for _, port in port_map:
+    for _unused, port in port_map:
         answerlist = []
         for host in qname:
             hostname = DNSName(host)


### PR DESCRIPTION
Fix a couple of deprecation warnings coming from IPA and python3-dns.

Also add support for DNS URI records. If the underlying IPA during the test execution contains support for URI records but that support isn't built into healthcheck then some tests will fail and output like this will be seen:

ERROR    root:idns.py:73 Unhandled rdtype 256
ERROR    root:idns.py:73 Unhandled rdtype 256
ERROR    root:idns.py:73 Unhandled rdtype 256
ERROR    root:idns.py:73 Unhandled rdtype 256
ERROR    root:idns.py:73 Unhandled rdtype 256
ERROR    root:idns.py:73 Unhandled rdtype 256
ERROR    root:idns.py:73 Unhandled rdtype 256
ERROR    root:idns.py:73 Unhandled rdtype 256

rdtype 256 == URI

So do this as an all-in-one shot since the DNS changes are related.