### PR TITLE
Include an exception on outer-level failures when running plugins

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -7,6 +7,7 @@ import json
 import logging
 import pkg_resources
 import warnings
+import traceback
 
 from datetime import datetime
 
@@ -51,7 +52,9 @@ def run_plugin(plugin, available=()):
             yield result
     except Exception as e:
         logger.debug('Exception raised: %s', e)
+        logger.debug(traceback.format_exc())
         yield Result(plugin, constants.CRITICAL, exception=str(e),
+                     traceback=traceback.format_exc(),
                      start=start)
 
 


### PR DESCRIPTION
The traceback will be both in the debug output and within the
Result value for the call so we have half a chance to fix what
is broken.

https://github.com/freeipa/freeipa-healthcheck/issues/224

Signed-off-by: Rob Crittenden <rcritten@redhat.com>