### PR TITLE
URI records are not required but if they exist they are validated.

### DIFF
--- a/tests/test_ipa_dns.py
+++ b/tests/test_ipa_dns.py
@@ -38,6 +38,15 @@ else:
 
 try:
     # pylint: disable=unused-import
+    from ipaserver.dns_data_management import IPA_DEFAULT_MASTER_URI_REC  # noqa
+except ImportError:
+    has_uri_support = False
+else:
+    has_uri_support = True
+
+
+try:
+    # pylint: disable=unused-import
     from ipaserver.install.installutils import resolve_rrsets_nss  # noqa: F401
     # pylint: enable=unused-import
 except ImportError:


### PR DESCRIPTION
This fixes support when testing with a version of IPA that does not
include URI support.

https://github.com/freeipa/freeipa-healthcheck/issues/222

Signed-off-by: Rob Crittenden <rcritten@redhat.com>