### PR TITLE
Unify command-line options and configuration

### DIFF
--- a/man/man5/ipahealthcheck.conf.5
+++ b/man/man5/ipahealthcheck.conf.5
@@ -36,6 +36,14 @@ The following options are relevant for the server:
 .TP
 .B cert_expiration_days\fR
 The number of days left before a certificate expires to start displaying a warning. The default is 28.
+.TP
+All command\-line options may be included in the configuration file. Dashes must be converted to underscore for the configuration file, e.g. \-\-output\-type becomes output_type. All options, including those that don't make sense in a config file, like \-\-list\-sources, are allowed. Let the buyer beware.
+.TP
+The purpose of allowing command\-line options to be in the configuration file is for automation without having to tweak the automation script. For example, if you want the default output type to be human for the systemd timer automated runs, settting output_type=human in the configuration file will do this. When loading configuration the first option wins, so if any option is in the configuration file then it cannot be overridden by the command-line unless a different configuration file is specified (see \-\-config).
+.TP
+There may be conflicting exceptions. For example, if all=True is set in the configuration file, and the command\-line contains \-\-failures\-only, then only failures will be displayed because of the way the option evaluation is done.
+.TP
+Options that don't make sense for the configuration file include \-\-list\-sources and \-\-input\-file.
 .SH "FILES"
 .TP
 .I /etc/ipahealthcheck/ipahealthcheck.conf
@@ -49,4 +57,4 @@ configuration file
  cert_expiration_days=7
 
 .SH "SEE ALSO"
-.BR ipa-healthcheck (8)
+.BR ipa\-healthcheck (8)

--- a/man/man8/ipa-healthcheck.8
+++ b/man/man8/ipa-healthcheck.8
@@ -30,6 +30,9 @@ Display a list of the available sources and the checks associated with those sou
 
 .SS "OPTIONAL ARGUMENTS"
 .TP
+\fB\-\-config\fR=\fIFILE\fR
+The configuration file to use. If an empty string is passed in then no configuration file is loaded. The default is /etc/ipahealthcheck/ipahealthcheck.conf.
+.TP
 \fB\-\-source\fR=\fISOURCE\fR
 Execute checks within the named source, or all sources in the given namespace.
 .TP

--- a/src/ipaclustercheck/core/output.py
+++ b/src/ipaclustercheck/core/output.py
@@ -14,7 +14,7 @@ class ClusterOutput(Output):
        severity doesn't apply in this case so exclude those.
     """
     def __init__(self, options):
-        self.filename = options.outfile
+        self.filename = options.output_file
 
     def strip_output(self, results):
         """Nothing to strip out"""

--- a/src/ipahealthcheck/core/config.py
+++ b/src/ipahealthcheck/core/config.py
@@ -63,7 +63,7 @@ class Config:
         """
         Merge variables from dict ``d`` into the configuration
 
-        The last one wins.
+        The first one wins.
 
         :param d: dict containing configuration
         """

--- a/src/ipahealthcheck/core/output.py
+++ b/src/ipahealthcheck/core/output.py
@@ -36,7 +36,7 @@ class Output:
        which will render the results into a string for writing.
     """
     def __init__(self, options):
-        self.filename = options.outfile
+        self.filename = options.output_file
 
         # Non-required options in the framework, set logical defaults to
         # pre 0.6 behavior with everything reported.
@@ -110,7 +110,7 @@ class JSON(Output):
 
     def __init__(self, options):
         super().__init__(options)
-        self.indent = options.indent
+        self.indent = int(options.indent)
 
     def generate(self, data):
         output = json.dumps(data, indent=self.indent)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,12 +10,12 @@ from ipahealthcheck.core.output import output_registry
 class RunChecks:
     def run_healthcheck(self):
         options = argparse.Namespace(check=None, debug=False, indent=2,
-                                     list_sources=False, outfile=None,
-                                     output='json', source=None,
+                                     list_sources=False, output_file=None,
+                                     output_type='json', source=None,
                                      verbose=False)
 
         for out in output_registry.plugins:
-            if out.__name__.lower() == options.output:
+            if out.__name__.lower() == options.output_type:
                 out(options)
                 break
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2022 FreeIPA Contributors see COPYING for license
+#
+
+import argparse
+import os
+import tempfile
+from unittest.mock import patch
+
+from ipahealthcheck.core.core import RunChecks
+from ipahealthcheck.core.plugin import Results
+
+options = argparse.Namespace(check=None, source=None, debug=False,
+                             indent=2, list_sources=False,
+                             output_type='json', output_file=None,
+                             verbose=False, version=False, config=None)
+
+
+@patch('ipahealthcheck.core.core.run_service_plugins')
+@patch('ipahealthcheck.core.core.run_plugins')
+@patch('ipahealthcheck.core.core.parse_options')
+def test_options_merge(mock_parse, mock_run, mock_service):
+    """
+    Test merging file-based and CLI options
+    """
+    mock_service.return_value = (Results(), [])
+    mock_run.return_value = Results()
+    mock_parse.return_value = options
+    fd, config_path = tempfile.mkstemp()
+    os.close(fd)
+    with open(config_path, "w") as fd:
+        fd.write('[default]\n')
+        fd.write('output_type=human\n')
+        fd.write('indent=5\n')
+
+    try:
+        run = RunChecks(['ipahealthcheck.registry'], config_path)
+
+        run.run_healthcheck()
+
+        # verify two valus that have defaults with our overriden values
+        assert run.options.output_type == 'human'
+        assert run.options.indent == '5'
+    finally:
+        os.remove(config_path)


### PR DESCRIPTION
This adds command-line options to the configuration, but not vice-versa.
It will allow for greater flexibility when running this automatically
without having to change any scripting.

https://bugzilla.redhat.com/show_bug.cgi?id=1872467

Signed-off-by: Rob Crittenden <rcritten@redhat.com>