### PR TITLE
Compare proxy shared secret configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
             'ipadns = ipahealthcheck.ipa.idns',
             'ipafiles = ipahealthcheck.ipa.files',
             'ipahost = ipahealthcheck.ipa.host',
+            'ipaproxy = ipahealthcheck.ipa.proxy',
             'ipameta = ipahealthcheck.ipa.meta',
             'iparoles = ipahealthcheck.ipa.roles',
             'ipatopology = ipahealthcheck.ipa.topology',

--- a/src/ipahealthcheck/ipa/proxy.py
+++ b/src/ipahealthcheck/ipa/proxy.py
@@ -1,0 +1,127 @@
+#
+# Copyright (C) 2021 FreeIPA Contributors see COPYING for license
+#
+
+import logging
+import lxml.etree
+import re
+
+from ipahealthcheck.ipa.plugin import IPAPlugin, registry
+from ipahealthcheck.core.plugin import Result
+from ipahealthcheck.core.plugin import duration
+from ipahealthcheck.core import constants
+
+from ipaplatform.paths import paths
+
+
+logger = logging.getLogger()
+
+
+def read_ipa_pki_proxy():
+    """Read the IPA Proxy configuration file
+
+       Split out to make it easier to mock
+    """
+    with open(paths.HTTPD_IPA_PKI_PROXY_CONF, "r") as fd:
+        lines = fd.readlines()
+
+    return lines
+
+
+@registry
+class IPAProxySecretCheck(IPAPlugin):
+    """
+    Ensure that the proxy secrets match between tomcat and Apache
+
+    Also report if tomcat has both secret and requiredSecret
+    defined and whether all three secrets match.
+    """
+    @duration
+    def check(self):
+        if not self.ca.is_configured():
+            logger.debug("CA is not configured, skipping IPAProxySecretCheck")
+            return
+
+        PROXY_SECRETS = 'proxy_secrets'
+
+        # so many things can go wrong just keep one big global to
+        # determine if we can eventually return SUCCESS
+        failures = False
+
+        server_xml = lxml.etree.parse(paths.PKI_TOMCAT_SERVER_XML)
+        doc = server_xml.getroot()
+
+        # no AJP connector means nothing to check
+        connectors = doc.xpath('//Connector[@protocol="AJP/1.3"]')
+        if len(connectors) == 0:
+            yield Result(self, constants.CRITICAL,
+                         key=PROXY_SECRETS,
+                         server_xml=paths.PKI_TOMCAT_SERVER_XML,
+                         msg='No AJP/1.3 Connectors defined in {server_xml}')
+            return
+
+        # IPA only deals with the first connect so that's all we'll check
+        connector = connectors[0]
+
+        ajp_secret = []
+        if 'secret' in connector.attrib:
+            ajp_secret.append(connector.attrib['secret'])
+
+        if 'requiredSecret' in connector.attrib:
+            ajp_secret.append(connector.attrib['requiredSecret'])
+
+        if len(ajp_secret) > 1:
+            if ajp_secret[0] != ajp_secret[1]:
+                failures = True
+                yield Result(
+                    self, constants.WARNING,
+                    key=PROXY_SECRETS,
+                    server_xml=paths.PKI_TOMCAT_SERVER_XML,
+                    msg='The AJP secrets in {server_xml} do not match'
+                )
+        # We could warn that both secret and requiredSecret are defined
+        # but the presence of both with the same password doesn't
+        # break anything so we will not warn for now.
+
+        lines = read_ipa_pki_proxy()
+
+        proxy_secrets = []
+        PROXY_RE = r'\s+ProxyPassMatch ajp://localhost:8009 secret=(\w+)$'
+        # Collect all the ipa-pki-proxy.conf secrets and ensure they all match
+        for line in lines:
+            m = re.match(PROXY_RE, line)
+            if m:
+                proxy_secrets.extend(m.groups(1))
+
+        if not proxy_secrets:
+            failures = True
+            yield Result(
+                self, constants.CRITICAL,
+                key=PROXY_SECRETS,
+                proxy_conf=paths.HTTPD_IPA_PKI_PROXY_CONF,
+                msg='No ProxyPassMatch secrets found in {proxy_conf}'
+            )
+            return
+
+        if len(set(proxy_secrets)) != 1:
+            failures = True
+            yield Result(
+                self, constants.CRITICAL,
+                key=PROXY_SECRETS,
+                proxy_conf=paths.HTTPD_IPA_PKI_PROXY_CONF,
+                msg='Not all ProxyPassMatch secrets match in {proxy_conf}'
+            )
+
+        for secret in proxy_secrets:
+            if secret not in ajp_secret:
+                failures = True
+                yield Result(
+                    self, constants.CRITICAL,
+                    key=PROXY_SECRETS,
+                    server_xml=paths.PKI_TOMCAT_SERVER_XML,
+                    msg='A ProxyPassMatch secret not found in {server_xml}'
+                )
+
+        if not failures:
+            yield Result(self, constants.SUCCESS,
+                         key=PROXY_SECRETS)

--- a/tests/test_ipa_proxy.py
+++ b/tests/test_ipa_proxy.py
@@ -1,0 +1,228 @@
+#
+# Copyright (C) 2021 FreeIPA Contributors see COPYING for license
+#
+
+from base import BaseTest
+from io import BytesIO
+from unittest.mock import patch
+from util import capture_results
+import lxml.etree
+
+from ipahealthcheck.core import config, constants
+from ipahealthcheck.meta.plugin import registry
+from ipahealthcheck.ipa.proxy import IPAProxySecretCheck
+
+# Pre-parse the XML to avoid Mock weirdness
+good_xml_input = """
+<Server port="8005" shutdown="SHUTDOWN">
+   <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" address="127.0.0.1" name="Connector1" secret="somesecret"/>
+   <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" address="::1" name="Connector1" secret="somesecret"/>
+</Server>
+"""  # noqa: E501
+good_xml = lxml.etree.parse(BytesIO(good_xml_input.encode('utf-8')))
+
+good_ipa_proxy = """
+<LocationMatch "^/ca/ee/ca/checkRequest">
+    SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
+    SSLVerifyClient none
+    ProxyPassMatch ajp://localhost:8009 secret=somesecret
+    ProxyPassReverse ajp://localhost:8009
+</LocationMatch>
+"""
+
+empty_ipa_proxy = """
+"""
+
+different_secrets_ipa_proxy = """
+<LocationMatch "^/ca/ee/ca/checkRequest">
+    SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
+    SSLVerifyClient none
+    ProxyPassMatch ajp://localhost:8009 secret=somesecret
+    ProxyPassReverse ajp://localhost:8009
+</LocationMatch>
+<LocationMatch "^/ca/ee/ca/checkRequest">
+    SSLOptions +StdEnvVars +ExportCertData +StrictRequire +OptRenegotiate
+    SSLVerifyClient none
+    ProxyPassMatch ajp://localhost:8009 secret=othersecret
+    ProxyPassReverse ajp://localhost:8009
+</LocationMatch>
+"""
+
+# server.xml secret won't match Apache secret
+mismatch1_xml_input = """
+<Server port="8005" shutdown="SHUTDOWN">
+   <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" address="127.0.0.1" name="Connector1" secret="badsecret"/>
+   <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" address="::1" name="Connector1" secret="badsecret"/>
+</Server>
+"""  # noqa: E501
+mismatch1_xml = lxml.etree.parse(BytesIO(mismatch1_xml_input.encode('utf-8')))
+
+both_secrets_xml_input = """
+<Server port="8005" shutdown="SHUTDOWN">
+   <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" address="127.0.0.1" name="Connector1" secret="somesecret" requiredSecret="somesecret"/>
+   <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" address="::1" name="Connector1" secret="somesecret" requiredSecret="somesecret"/>
+</Server>
+"""  # noqa: E501
+both_secrets_xml = lxml.etree.parse(
+    BytesIO(both_secrets_xml_input.encode('utf-8'))
+)
+
+both_secrets_mismatch_xml_input = """
+<Server port="8005" shutdown="SHUTDOWN">
+   <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" address="127.0.0.1" name="Connector1" secret="somesecret" requiredSecret="othersecret"/>
+   <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" address="::1" name="Connector1" secret="somesecret" requiredSecret="othersecret"/>
+</Server>
+"""  # noqa: E501
+both_secrets_mismatch_xml = lxml.etree.parse(
+    BytesIO(both_secrets_mismatch_xml_input.encode('utf-8'))
+)
+
+empty_xml_input = """
+<Server port="8005" shutdown="SHUTDOWN">
+</Server>
+"""
+empty_xml = lxml.etree.parse(BytesIO(empty_xml_input.encode('utf-8')))
+
+
+class TestIPAProxySecretCheck(BaseTest):
+    @patch('lxml.etree.parse')
+    @patch('ipahealthcheck.ipa.proxy.read_ipa_pki_proxy')
+    def test_matching_secrets(self, mock_proxy, mock_ltree):
+        """The passwords match"""
+        mock_ltree.return_value = good_xml
+        mock_proxy.return_value = good_ipa_proxy.split('\n')
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = IPAProxySecretCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+
+    @patch('lxml.etree.parse')
+    @patch('ipahealthcheck.ipa.proxy.read_ipa_pki_proxy')
+    def test_xml_both_secrets(self, mock_proxy, mock_ltree):
+        """server.xml defines both secret types and they match"""
+        mock_ltree.return_value = both_secrets_xml
+        mock_proxy.return_value = good_ipa_proxy.split('\n')
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = IPAProxySecretCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+
+    @patch('lxml.etree.parse')
+    @patch('ipahealthcheck.ipa.proxy.read_ipa_pki_proxy')
+    def test_xml_both_secret_type_mismatch(self, mock_proxy, mock_ltree):
+        """XML has both secret attributes and they do not match"""
+        mock_ltree.return_value = both_secrets_mismatch_xml
+        mock_proxy.return_value = good_ipa_proxy.split('\n')
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = IPAProxySecretCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.WARNING
+        assert result.kw.get('msg') == 'The AJP secrets in {server_xml} do '\
+                                       'not match'
+
+    @patch('lxml.etree.parse')
+    @patch('ipahealthcheck.ipa.proxy.read_ipa_pki_proxy')
+    def test_xml_secret_mismatch(self, mock_proxy, mock_ltree):
+        """The Apache secret doesn't match the tomcat secret"""
+        mock_ltree.return_value = mismatch1_xml
+        mock_proxy.return_value = good_ipa_proxy.split('\n')
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = IPAProxySecretCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.CRITICAL
+        assert result.kw.get('msg') == 'A ProxyPassMatch secret not found ' \
+                                       'in {server_xml}'
+
+    @patch('lxml.etree.parse')
+    @patch('ipahealthcheck.ipa.proxy.read_ipa_pki_proxy')
+    def test_xml_no_connectors(self, mock_proxy, mock_ltree):
+        """No connectors found in server.xml"""
+        mock_ltree.return_value = empty_xml
+        mock_proxy.return_value = good_ipa_proxy.split('\n')
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = IPAProxySecretCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.CRITICAL
+        assert result.kw.get('msg') == 'No AJP/1.3 Connectors defined in ' \
+                                       '{server_xml}'
+
+    @patch('lxml.etree.parse')
+    @patch('ipahealthcheck.ipa.proxy.read_ipa_pki_proxy')
+    def test_no_proxypassmatch(self, mock_proxy, mock_ltree):
+        """No connectors found in server.xml"""
+        mock_ltree.return_value = good_xml
+        mock_proxy.return_value = empty_ipa_proxy.split('\n')
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = IPAProxySecretCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.CRITICAL
+        assert result.kw.get('msg') == 'No ProxyPassMatch secrets found ' \
+                                       'in {proxy_conf}'
+
+    @patch('lxml.etree.parse')
+    @patch('ipahealthcheck.ipa.proxy.read_ipa_pki_proxy')
+    def test_proxypassmatch_different_secrets(self, mock_proxy, mock_ltree):
+        """No connectors found in server.xml"""
+        mock_ltree.return_value = good_xml
+        mock_proxy.return_value = different_secrets_ipa_proxy.split('\n')
+
+        framework = object()
+        registry.initialize(framework, config.Config())
+        f = IPAProxySecretCheck(registry)
+
+        self.results = capture_results(f)
+
+        print(self.results.results)
+        assert len(self.results) == 2
+
+        result = self.results.results[0]
+        assert result.result == constants.CRITICAL
+        assert result.kw.get('msg') == 'Not all ProxyPassMatch secrets ' \
+                                       'match in {proxy_conf}'
+
+        result = self.results.results[1]
+        assert result.result == constants.CRITICAL
+        assert result.kw.get('msg') == 'A ProxyPassMatch secret not found ' \
+                                       'in {server_xml}'


### PR DESCRIPTION
Compare the ProxyPassMatch secret(s) with those in server.xml

For now we are skipping checking to see if both secret and
requiredSecret are configured since it doesn't seem to cause
tomcat any issues. As long as the secrets match up with
ipa-pki-proxy.conf then things work fine.

https://github.com/freeipa/freeipa-healthcheck/issues/231

Signed-off-by: Rob Crittenden <rcritten@redhat.com>