### PR TITLE
Check expected group memberships

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
             'ipafiles = ipahealthcheck.ipa.files',
             'ipahost = ipahealthcheck.ipa.host',
             'ipameta = ipahealthcheck.ipa.meta',
+            'ipanss = ipahealthcheck.ipa.nss',
             'iparoles = ipahealthcheck.ipa.roles',
             'ipatopology = ipahealthcheck.ipa.topology',
             'ipatrust = ipahealthcheck.ipa.trust',

--- a/src/ipahealthcheck/ipa/nss.py
+++ b/src/ipahealthcheck/ipa/nss.py
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2021 FreeIPA Contributors see COPYING for license
+#
+
+import grp
+import logging
+
+from ipahealthcheck.ipa.plugin import IPAPlugin, registry
+from ipahealthcheck.core.plugin import Result
+from ipahealthcheck.core.plugin import duration
+from ipahealthcheck.core import constants
+
+logger = logging.getLogger()
+
+# A tuple of groups and a tuple of expected members
+#
+# For example the apache user needs to be in the ipaapi group so
+# the tuple would look like: 'ipaapi', ('apache',).
+#
+# The second value is a tuple so that we can more easily extend if
+# multiple users need to be a member of a group.
+#
+# (group_name, (members,))
+GROUP_MEMBERS = (
+    ('ipaapi', ('apache',)),
+)
+
+
+@registry
+class IPAGroupMemberCheck(IPAPlugin):
+    """
+    Ensure that nss/POSIX group membership is as expected.
+
+    This can be critical for security and/or proper access control and
+    is primarily being checked for privilege separation. The ipaapi
+    user needs to be able to read ccaches created by Apache.
+    """
+    @duration
+    def check(self):
+        for (group, members) in GROUP_MEMBERS:
+            try:
+                grp_group = grp.getgrnam(group)
+            except KeyError:
+                yield Result(self, constants.ERROR,
+                             key=group,
+                             msg='group {key} does not exist')
+                continue
+            for member in members:
+                if member not in grp_group.gr_mem:
+                    yield Result(self, constants.ERROR,
+                                 key=group,
+                                 member=member,
+                                 msg='{member} is not a member of group {key}')
+                else:
+                    yield Result(self, constants.SUCCESS,
+                                 key=group,
+                                 member=member)

--- a/tests/test_ipa_nss.py
+++ b/tests/test_ipa_nss.py
@@ -1,0 +1,76 @@
+#
+# Copyright (C) 2021 FreeIPA Contributors see COPYING for license
+#
+
+from base import BaseTest
+from collections import namedtuple
+from unittest.mock import patch
+from util import capture_results
+
+from ipahealthcheck.core import config, constants
+from ipahealthcheck.ipa.plugin import registry
+from ipahealthcheck.ipa.nss import IPAGroupMemberCheck
+
+
+struct_group = namedtuple(
+    'struct_group', ['gr_name', 'gr_passwd', 'gr_gid', 'gr_mem']
+)
+
+
+def make_group(name, members):
+    return struct_group(name, 'x', 999, members)
+
+
+class TestGroupMember(BaseTest):
+    @patch('grp.getgrnam')
+    def test_ipaapi_group_ok(self, mock_grp):
+        mock_grp.return_value = make_group('apache', ('apache', 'ipaapi',))
+
+        framework = object()
+        registry.initialize(framework, config.Config)
+        registry.trust_agent = True
+        f = IPAGroupMemberCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+
+    @patch('grp.getgrnam')
+    def test_ipaapi_bad_group(self, mock_grp):
+        mock_grp.side_effect = KeyError("name not found: 'ipaapi'")
+
+        framework = object()
+        registry.initialize(framework, config.Config)
+        registry.trust_agent = True
+        f = IPAGroupMemberCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.ERROR
+        assert result.kw.get('key') == 'ipaapi'
+        assert result.kw.get('msg') == 'group {key} does not exist'
+
+    @patch('grp.getgrnam')
+    def test_ipaapi_missing_member(self, mock_grp):
+        mock_grp.return_value = make_group('apache', ('foo',))
+
+        framework = object()
+        registry.initialize(framework, config.Config)
+        registry.trust_agent = True
+        f = IPAGroupMemberCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.ERROR
+        assert result.kw.get('key') == 'ipaapi'
+        assert result.kw.get('msg') == \
+            '{member} is not a member of group {key}'


### PR DESCRIPTION
The initial purpose of this is for privilege separation
where if the group membership is not correct the ccaches
may not be readable. It's possible this will expand to other
purposes.

https://github.com/freeipa/freeipa-healthcheck/issues/233

Signed-off-by: Rob Crittenden <rcritten@redhat.com>