### PR TITLE
core: Relax dependency on IPA stuff

### DIFF
--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -8,11 +8,18 @@ import sys
 from ipahealthcheck.core import constants
 from ipahealthcheck.core.core import RunChecks
 
-from ipalib.facts import is_ipa_configured
+try:
+    from ipalib.facts import is_ipa_configured
+except ImportError:
+    is_ipa_configured = None
 
 
 class IPAChecks(RunChecks):
     def pre_check(self):
+        if is_ipa_configured is None:
+            print("IPA server is not installed")
+            return 1
+
         if not is_ipa_configured():
             print("IPA server is not configured")
             return 1

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,6 +5,7 @@
 import os
 
 from ipapython.ipautil import run
+import pytest
 
 
 def test_version():
@@ -13,3 +14,44 @@ def test_version():
     """
     output = run(['ipa-healthcheck', '--version'], env=os.environ)
     assert 'ipahealthcheck' in output.raw_output.decode('utf-8')
+
+
+@pytest.fixture
+def python_ipalib_dir(tmpdir):
+    ipalib_dir = tmpdir.mkdir("ipalib")
+    ipalib_dir.join("__init__.py").write("")
+
+    def _make_facts(configured=None):
+        if configured is None:
+            module_text = ""
+        elif isinstance(configured, bool):
+            module_text = f"def is_ipa_configured(): return {configured}"
+        else:
+            raise TypeError(
+                f"'configured' must be None or bool, got '{configured!r}'"
+            )
+
+        ipalib_dir.join("facts.py").write(module_text)
+        return str(tmpdir)
+
+    return _make_facts
+
+
+def test_ipa_notinstalled(python_ipalib_dir, monkeypatch):
+    """
+    Test ipa-healthcheck handles the missing IPA stuff
+    """
+    monkeypatch.setenv("PYTHONPATH", python_ipalib_dir(configured=None))
+    output = run(["ipa-healthcheck"], raiseonerr=False, env=os.environ)
+    assert output.returncode == 1
+    assert "IPA server is not installed" in output.raw_output.decode("utf-8")
+
+
+def test_ipa_unconfigured(python_ipalib_dir, monkeypatch):
+    """
+    Test ipa-healthcheck handles the unconfigured IPA server
+    """
+    monkeypatch.setenv("PYTHONPATH", python_ipalib_dir(configured=False))
+    output = run(["ipa-healthcheck"], raiseonerr=False, env=os.environ)
+    assert output.returncode == 1
+    assert "IPA server is not configured" in output.raw_output.decode("utf-8")


### PR DESCRIPTION
The core plugin system ideally should not depend on IPA, but the
freeipa-healthcheck plugin itself. For example, being reusable the
core may be called outside of console script (ipa-healthcheck) by
any lib/application (if ipaserver is not installed):

```console
[root@281a5762c1bd /]# python3 -c 'import ipahealthcheck.core.main as main; main.main()'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.10/site-packages/ipahealthcheck/core/main.py", line 12, in <module>
    from ipaserver.install.installutils import is_ipa_configured
ModuleNotFoundError: No module named 'ipaserver'
```

Actual problem is that every plugin of healthcheck system gains extra
IPA stack as the indirect dependency even if IPA is not used by a plugin.
For example, in ALTLinux dogtag-pki-server requires freeipa-healthcheck-core
which in turn, wants ipaserver, but actually dogtag-pki-server works
just fine without the latter. Moreover, this can lead to build loops
known as bootstrap issues like `dogtag -> healthcheck -> ipa -> dogtag`.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/237