### PR TITLE
Add a timeout wrapper around each check execution

### DIFF
--- a/man/man5/ipahealthcheck.conf.5
+++ b/man/man5/ipahealthcheck.conf.5
@@ -37,6 +37,9 @@ The following options are relevant for the server:
 .B cert_expiration_days\fR
 The number of days left before a certificate expires to start displaying a warning. The default is 28.
 .TP
+.B timeout\fR
+The time allowed in seconds for each check to run before being considered an error. The default is 10.
+.TP
 All command\-line options may be included in the configuration file. Dashes must be converted to underscore for the configuration file, e.g. \-\-output\-type becomes output_type. All options, including those that don't make sense in a config file, like \-\-list\-sources, are allowed. Let the buyer beware.
 .TP
 The purpose of allowing command\-line options to be in the configuration file is for automation without having to tweak the automation script. For example, if you want the default output type to be human for the systemd timer automated runs, settting output_type=human in the configuration file will do this. When loading configuration the first option wins, so if any option is in the configuration file then it cannot be overridden by the command-line unless a different configuration file is specified (see \-\-config).
@@ -55,6 +58,7 @@ configuration file
 
  [default]
  cert_expiration_days=7
+ timeout=5
 
 .SH "SEE ALSO"
 .BR ipa\-healthcheck (8)

--- a/src/ipahealthcheck/core/constants.py
+++ b/src/ipahealthcheck/core/constants.py
@@ -60,6 +60,9 @@ def getLevel(name):
 CONFIG_FILE = '/etc/ipahealthcheck/ipahealthcheck.conf'
 CONFIG_SECTION = 'default'
 
+DEFAULT_TIMEOUT = 10
+
 DEFAULT_CONFIG = {
     'cert_expiration_days': 28,
+    'timeout': DEFAULT_TIMEOUT,
 }

--- a/src/ipahealthcheck/core/exceptions.py
+++ b/src/ipahealthcheck/core/exceptions.py
@@ -1,0 +1,6 @@
+#
+# Copyright (C) 2021 FreeIPA Contributors see COPYING for license
+#
+
+class TimeoutError(Exception):
+    pass

--- a/src/ipahealthcheck/meta/core.py
+++ b/src/ipahealthcheck/meta/core.py
@@ -6,6 +6,7 @@ import logging
 import os
 import socket
 from ipahealthcheck.core import constants
+from ipahealthcheck.core.exceptions import TimeoutError
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.meta.plugin import Plugin, registry
 from ipapython import ipautil
@@ -34,6 +35,10 @@ class MetaCheck(Plugin):
                                       '--is-enabled'],
                                      capture_output=True,
                                      raiseonerr=False,)
+            except TimeoutError:
+                logger.debug('fips-mode-setup timed out')
+                fips = "check timed out"
+                rval = constants.ERROR
             except Exception as e:
                 logger.debug('fips-mode-setup failed: %s', e)
                 fips = "failed to check"
@@ -58,6 +63,10 @@ class MetaCheck(Plugin):
                 result = ipautil.run(['ipa-acme-manage', 'status'],
                                      capture_output=True,
                                      raiseonerr=False,)
+            except TimeoutError:
+                logger.debug('ipa-acme-manage timed out')
+                acme = "check timed out"
+                rval = constants.ERROR
             except Exception as e:
                 logger.debug('ipa-acme-manage failed: %s', e)
                 acme = "failed to check"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2021 FreeIPA Contributors see COPYING for license
+#
+
+import time
+
+from ipahealthcheck.core.plugin import Plugin, Registry, Result
+from ipahealthcheck.core.core import run_plugins
+from ipahealthcheck.core import constants
+
+
+def test_timeout():
+    """
+    Test that timeouts are detected.
+    """
+    class plugin1(Plugin):
+        def check(self):
+            time.sleep(5)
+
+    class plugin2(Plugin):
+        def check(self):
+            yield Result(self, constants.SUCCESS, key='test', msg='pass')
+
+    # Create a registry
+    r = Registry()
+
+    # Register the plugins
+    r(plugin1)
+    r(plugin2)
+
+    # Collect the results
+    results = run_plugins(r.get_plugins(), (), None, None, timeout=1)
+
+    assert len(results.results) == 2
+
+    assert results.results[0].result == constants.ERROR
+    assert results.results[0].kw.get('exception') == 'Request timed out'
+
+    assert results.results[1].result == constants.SUCCESS
+    assert results.results[1].kw.get('msg') == 'pass'


### PR DESCRIPTION
A timeout will raise a new exception, TimeoutError. This
can be caught and handled inside an individual check, otherwise
it will be handled by run_plugin.

https://github.com/freeipa/freeipa-healthcheck/issues/236

Signed-off-by: Rob Crittenden <rcritten@redhat.com>