### PR TITLE
add support for prometheus text metric exposition format output.

### DIFF
--- a/man/man8/ipa-healthcheck.8
+++ b/man/man8/ipa-healthcheck.8
@@ -37,7 +37,7 @@ Execute checks within the named source, or all sources in the given namespace.
 Execute this particular check within a source. The exact source must also be specified via \fB\-\-source\fR.
 .TP
 \fB\-\-output\-type\fR=\fITYPE\fR
-Set the output type. Supported variants are \fBhuman\fR and \fBjson\fR. The default is \fBjson\fR.
+Set the output type. Supported variants are \fBhuman\fR, \fBjson\fR, and \fBprometheus\fR. The default is \fBjson\fR.
 .TP
 \fB\-\-failures\-only\fR
 Exclude SUCCESS results on output. If stdin is a tty then this will default to True. In all other cases it defaults to False.
@@ -71,6 +71,14 @@ The results are displayed in a more human\-readable format.
 .TP
 \fB\-\-input\-file\fR=\fIFILENAME\fR
 Take as input a JSON results output and convert it to a more human\-readable form.
+
+.SS "PROMETHEUS OUTPUT"
+The results are displayed in the Prometheus text metric exposition format.
+.TP
+\fB\-\-input\-file\fR=\fIFILENAME\fR
+Uses the JSON-formatted results output as metrics source.
+\fB\-\-metric\-prefix\fR=\fIPREFIX\fR
+Prefix to use for metric names.
 
 .SH "EXAMPLES"
 .PP


### PR DESCRIPTION
this new output plugin generates metrics from the check results in the prometheus
text exposition format. it is intended to be used in combination with the
prometheus node_exporter [textfile collector][]. the output plugin generates
similar metrics as the [ipahealthcheck_exporter][].

[textfile collector]: https://github.com/prometheus/node_exporter#textfile-collector
[ipahealthcheck_exporter]: https://github.com/camptocamp/ipahealthcheck_exporter

an example output of the plugin:

```
# HELP ipa_cert_expiration Expiration date of certificates in warning/error state
# TYPE ipa_cert_expiration gauge
ipa_cert_expiration{certificate_request_id="20200416134554"} 1.618580754e+09
# HELP ipa_service_state State of the services monitored by IPA healthcheck
# TYPE ipa_service_state gauge
ipa_service_state{service="certmonger"} 1.0
ipa_service_state{service="dirsrv"} 1.0
ipa_service_state{service="gssproxy"} 1.0
ipa_service_state{service="httpd"} 1.0
ipa_service_state{service="ipa_custodia"} 1.0
ipa_service_state{service="ipa_dnskeysyncd"} 1.0
ipa_service_state{service="ipa_otpd"} 1.0
ipa_service_state{service="kadmin"} 1.0
ipa_service_state{service="krb5kdc"} 1.0
ipa_service_state{service="named"} 1.0
ipa_service_state{service="pki_tomcatd"} 1.0
ipa_service_state{service="sssd"} 1.0
# HELP ipa_healthcheck Number of healthchecks with a certain result
# TYPE ipa_healthcheck gauge
ipa_healthcheck{result="SUCCESS"} 244.0
ipa_healthcheck{result="WARNING"} 1.0
```