### PR TITLE
fixups for skipping the pki healthchecks

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -306,7 +306,7 @@ class RunChecks:
         # which should set ca_configured in its registry to True or
         # False. We will skip the pkihealthcheck plugins only if
         # ca_configured is False which means that it was set by IPA.
-        ca_configured = None
+        ca_configured = False
         for name, registry in find_registries(self.entry_points).items():
             try:
                 registry.initialize(framework, config, options)
@@ -320,6 +320,7 @@ class RunChecks:
                     continue
             if hasattr(registry, 'ca_configured'):
                 ca_configured = registry.ca_configured
+        for name, registry in find_registries(self.entry_points).items():
             if 'pkihealthcheck' in name and ca_configured is False:
                 logger.debug('IPA CA is not configured, skipping %s', name)
                 continue

--- a/src/ipahealthcheck/ipa/plugin.py
+++ b/src/ipahealthcheck/ipa/plugin.py
@@ -59,6 +59,9 @@ class IPARegistry(Registry):
                 logger.debug('Failed to connect to LDAP: %s', e)
             return
 
+        ca = cainstance.CAInstance(api.env.realm, host_name=api.env.host)
+        self.ca_configured = ca.is_configured()
+
         # This package is pulled in when the trust package is installed
         # and is required to lookup trust users. If this is not installed
         # then it can be inferred that trust is not enabled.
@@ -84,9 +87,6 @@ class IPARegistry(Registry):
         role = roles[1].status(api)[0]
         if role.get('status') == 'enabled':
             self.trust_controller = True
-
-        ca = cainstance.CAInstance(api.env.realm, host_name=api.env.host)
-        self.ca_configured = ca.is_configured()
 
 
 registry = IPARegistry()


### PR DESCRIPTION
The pki healthchecks spew a lot of errors if a CA is not configured rather than gracefully reporting nothing.

A few corner cases in healthcheck skipping those were discovered and (hopefully) addressed.