### PR TITLE
Pylint 2.12

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -49,9 +49,10 @@ jobs:
                 freeipa-server \
                 freeipa-server-trust-ad \
                 tox \
-                python3-pylint \
+                python3-pip \
                 python3-pytest \
                 ; \
+            python3 -m pip install --user --ignore-installed 'pylint ~= 2.12.2' ; \
             cd /root/src; \
             tox -vv -elint; \
             "
@@ -65,7 +66,6 @@ jobs:
                 freeipa-server \
                 freeipa-server-trust-ad \
                 tox \
-                python3-pylint \
                 python3-pytest \
                 ; \
             cd /root/src; \

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -406,6 +406,7 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.container_automount = DN()
     api.env.container_ca = DN()
     api.env.container_ca_renewal = DN()
+    api.env.container_subids = DN()
     api.env.container_caacl = DN()
     api.env.container_certmap = DN()
     api.env.container_certmaprules = DN()
@@ -470,10 +471,6 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.interactive = True
     api.env.ipalib = ''  # object
     api.env.kinit_lifetime = None
-    api.env.lite_pem = ''
-    api.env.lite_profiler = ''
-    api.env.lite_host = ''
-    api.env.lite_port = 0
     api.env.log = ''  # object
     api.env.logdir = ''  # object
     api.env.mode = ''
@@ -500,6 +497,32 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.version = ''
     api.env.wait_for_dns = 0
     api.env.webui_prod = True
+
+    # defined in ipaclient/install/ipa_epn.py
+    api.env.smtp_server = ""
+    api.env.smtp_port = 0
+    api.env.smtp_user = None
+    api.env.smtp_password = None
+    api.env.smtp_client_cert = None
+    api.env.smtp_client_key = None
+    api.env.smtp_client_key_pass = None
+    api.env.smtp_timeout = 0
+    api.env.smtp_security = ""
+    api.env.smtp_admin = ""
+    api.env.smtp_delay = None
+    api.env.mail_from = None
+    api.env.notify_ttls = ""
+    api.env.msg_charset = ""
+    api.env.msg_subtype = ""
+    api.env.msg_subject = ""
+
+    # defined in contrib/lite-server.py
+    api.env.lite_pem = ''
+    api.env.lite_profiler = ''
+    api.env.lite_host = ''
+    api.env.lite_port = 0
+    api.env.lite_tracemalloc = False
+
     """
 ))
 

--- a/pylintrc
+++ b/pylintrc
@@ -122,6 +122,7 @@ disable=
     use-dict-literal,  # pylint 2.10.0 dict vs {}
     use-list-literal,  # pylint 2.10.0 list() vs []
     unspecified-encoding,  # pylint 2.10.0, ASCII or UTF8 and platform-specific
+    use-implicit-booleaness-not-comparison,  # pylint 2.12.2, weak comparison
 
 [REPORTS]
 

--- a/pylintrc
+++ b/pylintrc
@@ -28,10 +28,18 @@ valid-metaclass-classmethod-first-arg=cls
 
 enable=
     all,
-    python3
+    python3,
+    useless-suppression,
 
 disable=
-    I,
+    bad-inline-option,
+    c-extension-no-member,
+    deprecated-pragma,
+    file-ignored,
+    locally-disabled,
+    raw-checker-failed,
+    suppressed-message,
+    use-symbolic-message-instead,
     duplicate-code,
     interface-not-implemented,
     no-self-use,

--- a/pylintrc
+++ b/pylintrc
@@ -111,6 +111,8 @@ disable=
     consider-using-min-builtin,  # pylint 2.8.0, can be more readable
     redundant-u-string-prefix,  # pylint 2.10.0, too many unessential changes
     consider-using-f-string,  # pylint 2.11.0, format can be more readable
+    use-dict-literal,  # pylint 2.10.0 dict vs {}
+    use-list-literal,  # pylint 2.10.0 list() vs []
 
 [REPORTS]
 

--- a/pylintrc
+++ b/pylintrc
@@ -113,6 +113,7 @@ disable=
     consider-using-f-string,  # pylint 2.11.0, format can be more readable
     use-dict-literal,  # pylint 2.10.0 dict vs {}
     use-list-literal,  # pylint 2.10.0 list() vs []
+    unspecified-encoding,  # pylint 2.10.0, ASCII or UTF8 and platform-specific
 
 [REPORTS]
 

--- a/pylintrc
+++ b/pylintrc
@@ -110,6 +110,7 @@ disable=
     consider-using-max-builtin,  # pylint 2.8.0, can be more readable
     consider-using-min-builtin,  # pylint 2.8.0, can be more readable
     redundant-u-string-prefix,  # pylint 2.10.0, too many unessential changes
+    consider-using-f-string,  # pylint 2.11.0, format can be more readable
 
 [REPORTS]
 

--- a/pylintrc
+++ b/pylintrc
@@ -62,7 +62,6 @@ disable=
     bad-builtin,
     bad-indentation,
     broad-except,
-    consider-using-dict-items,
     dangerous-default-value,
     eval-used,
     exec-used,

--- a/pylintrc
+++ b/pylintrc
@@ -109,6 +109,7 @@ disable=
     consider-using-with,  # pylint 2.8.0, contextmanager is not mandatory
     consider-using-max-builtin,  # pylint 2.8.0, can be more readable
     consider-using-min-builtin,  # pylint 2.8.0, can be more readable
+    redundant-u-string-prefix,  # pylint 2.10.0, too many unessential changes
 
 [REPORTS]
 

--- a/src/ipahealthcheck/ipa/idns.py
+++ b/src/ipahealthcheck/ipa/idns.py
@@ -98,14 +98,13 @@ class IPADNSSystemRecordsCheck(IPAPlugin):
         # For each SRV record that IPA thinks it should have, do a DNS
         # lookup of it and ensure that DNS has the same set of values
         # that IPA thinks it should.
-        for srv in srv_rec:
+        for srv, hosts in srv_rec.items():
             logger.debug("Search DNS for SRV record of %s", srv)
             try:
                 answers = query_srv(srv)
             except DNSException as e:
                 logger.debug("DNS record not found: %s", e.__class__.__name__)
                 answers = []
-            hosts = srv_rec[srv]
             for answer in answers:
                 logger.debug("DNS record found: %s", answer)
                 try:
@@ -124,10 +123,9 @@ class IPADNSSystemRecordsCheck(IPAPlugin):
                     msg='Expected SRV record missing',
                     key=self.srv_to_name(srv, host))
 
-        for uri in uri_rec:
+        for uri, hosts in uri_rec.items():
             logger.debug("Search DNS for URI record of %s", uri)
             answers = query_uri(uri)
-            hosts = uri_rec[uri]
             for answer in answers:
                 logger.debug("DNS record found: %s", answer)
                 try:
@@ -153,7 +151,7 @@ class IPADNSSystemRecordsCheck(IPAPlugin):
                     key=self.uri_to_name(uri, host)
                 )
 
-        for txt in txt_rec:
+        for txt, realms in txt_rec.items():
             logger.debug("Search DNS for TXT record of %s", txt)
             try:
                 answers = resolve(txt, rdatatype.TXT)
@@ -161,7 +159,6 @@ class IPADNSSystemRecordsCheck(IPAPlugin):
                 logger.debug("DNS record not found: %s", e.__class__.__name__)
                 answers = []
 
-            realms = txt_rec[txt]
             for answer in answers:
                 logger.debug("DNS record found: %s", answer)
                 realm = answer.to_text()

--- a/src/ipahealthcheck/system/filesystemspace.py
+++ b/src/ipahealthcheck/system/filesystemspace.py
@@ -61,7 +61,7 @@ class FileSystemSpaceCheck(SystemPlugin):
 
     @duration
     def check(self):
-        for store in self._pathchecks:
+        for store, threshold in self._pathchecks.items():
             try:
                 percent_free = self.get_fs_free_space_percentage(store)
             except FileNotFoundError:
@@ -95,7 +95,6 @@ class FileSystemSpaceCheck(SystemPlugin):
                     threshold=self.min_free_percent
                 )
             free_space = self.get_fs_free_space(store)
-            threshold = self._pathchecks[store]
             if free_space < threshold:
                 yield Result(
                     self, constants.ERROR,

--- a/tests/test_ipa_dns.py
+++ b/tests/test_ipa_dns.py
@@ -96,8 +96,8 @@ def query_uri(hosts):
     if version.MAJOR < 2 or (version.MAJOR == 2 and version.MINOR == 0):
         m = message.Message()
     elif version.MAJOR == 2 and version.MINOR > 0:
-        m = message.QueryMessage()  # pylint: disable=E1101
-        m = message.make_response(m)  # pylint: disable=E1101
+        m = message.QueryMessage()
+        m = message.make_response(m)
 
     rdtype = rdatatype.URI
     for name in ('_kerberos.', '_kpasswd.'):
@@ -158,8 +158,8 @@ def fake_query(qname, rdtype=rdatatype.A, rdclass=rdataclass.IN, count=1,
     if version.MAJOR < 2 or (version.MAJOR == 2 and version.MINOR == 0):
         m = message.Message()
     elif version.MAJOR == 2 and version.MINOR > 0:
-        m = message.QueryMessage()  # pylint: disable=E1101
-        m = message.make_response(m)  # pylint: disable=E1101
+        m = message.QueryMessage()
+        m = message.make_response(m)
     if rdtype in (rdatatype.A, rdatatype.AAAA):
         fqdn = DNSName(qname)
         fqdn = fqdn.make_absolute()


### PR DESCRIPTION
disabled:
- `consider-using-f-string`
- `redundant-u-string-prefix`
- `use-dict-literal`
- `unspecified-encoding`
- `use-list-literal`

enabled:
- `useless-suppression`

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/244