### PR TITLE
Don't depend on IPA status when suppressing pki checks

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -372,13 +372,23 @@ class RunChecks:
         if rval is not None:
             return rval
 
+        # The pki checks are noisy if a CA is not configured so we
+        # want to suppress that for IPA.
+        #
+        # There are 3 possible states:
+        # 1. IPA is configured with a CA
+        # 2. IPA is configured without a CA
+        # 3. IPA is not configured
+        #
         # If we have IPA configured without a CA then we want to skip
-        # the pkihealthcheck plugins otherwise they will generated a
-        # lot of false positives. The IPA plugins are loaded first so
-        # which should set ca_configured in its registry to True or
-        # False. We will skip the pkihealthcheck plugins only if
-        # ca_configured is False which means that it was set by IPA.
-        ca_configured = False
+        # the pkihealthcheck plugins
+        #
+        # The IPA registry will set ca_configured in its registry to True
+        # or False. We will skip the pkihealthcheck plugins only if
+        # ca_configured is False which means that it was set by IPA. So
+        # we initialize ca_configured to None so that the pki checks
+        # will always be executed with pki-healthcheck.
+        ca_configured = None
         for name, registry in find_registries(self.entry_points).items():
             try:
                 registry.initialize(framework, config, options)


### PR DESCRIPTION
The pki healthchecks are noisy if a CA is not configured. We
want to suppresse these in IPA so don't make the checks visible
if a CA is not configured.

So this means we need to be able to run in these conditions:

1. IPA is configured with a CA: the pki checks are run
2. IPA is configured without a CA: the pki checks are not run
3. IPA is not configured: the pki checks are run

Which basically equates to three states: True, False, None

This was done originally with the ca_configured variable set to
None. Using some inside knowledge the registries are loaded which
will set ca_configured to True or False in the IPA registry.
Using that we can determine if the pki checks should be available.
Unfortunately I changed the initialization to False so it always
assumes that IPA is installed. ca_configured will be False for the
case of IPA not installed instead of None so we can't handle that
last state.

So initialize ca_configured to False so we can satisfy all three
states.

https://github.com/freeipa/freeipa-healthcheck/issues/201

Signed-off-by: Rob Crittenden <rcritten@redhat.com>