### PR TITLE
gha: Drop Fedora 33

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ['3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fedora-release: [33, 34]
+        fedora-release: [34, 35]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- dropped Fedora 33 due to EOL (since Dec1 2021):
  https://docs.fedoraproject.org/en-US/releases/eol/

- added released Fedora 35
  https://fedorapeople.org/groups/schedule/f-35/f-35-key-tasks.html

- added Python3.10 for flake8/pep8 tasks

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/251
Signed-off-by: Stanislav Levin <slev@altlinux.org>