### PR TITLE
Use the subject base from the IPA configuration, not REALM

### DIFF
--- a/tests/test_ipa_proxy.py
+++ b/tests/test_ipa_proxy.py
@@ -214,7 +214,6 @@ class TestIPAProxySecretCheck(BaseTest):
 
         self.results = capture_results(f)
 
-        print(self.results.results)
         assert len(self.results) == 2
 
         result = self.results.results[0]


### PR DESCRIPTION
Use the subject base from the IPA configuration, not REALM

The expected certificates were hardcoded with O={REALM} which
would return false-positives if the customer defined their
own certificate subject base.

Also add a search filter to only retrieve the certificate(s) we
want to examine rather than the entire contents.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/253

Signed-off-by: Rob Crittenden <rcritten@redhat.com>