### PR TITLE
Fixes for configuration file support for cli options

### DIFF
--- a/src/ipahealthcheck/core/config.py
+++ b/src/ipahealthcheck/core/config.py
@@ -109,7 +109,8 @@ def read_config(config_file):
         )
         return config
 
-    parser = ConfigParser(dict_type=DuplicateOrderedDict, strict=False)
+    parser = ConfigParser(dict_type=DuplicateOrderedDict, strict=False,
+                          delimiters='=')
     try:
         parser.read(config_file)
     except ParsingError as e:
@@ -125,7 +126,14 @@ def read_config(config_file):
 
     for (key, value) in items:
         if not key.startswith('excludes_'):
-            config[key] = value
+            if len(value) == 0 or value is None:
+                logging.error(
+                    "Empty value for %s in %s [%s]",
+                    key, config_file, CONFIG_SECTION
+                )
+                return None
+            else:
+                config[key] = value
 
     if parser.has_section(EXCLUDE_SECTION):
         items = parser.items(EXCLUDE_SECTION)

--- a/src/ipahealthcheck/core/constants.py
+++ b/src/ipahealthcheck/core/constants.py
@@ -2,8 +2,6 @@
 # Copyright (C) 2019 FreeIPA Contributors see COPYING for license
 #
 
-DEFAULT_OUTPUT = 'json'
-
 # Error reporting result
 SUCCESS = 0
 WARNING = 10

--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -439,7 +439,7 @@ class RunChecks:
                                                      options.check)
             results.extend(run_plugins(plugins, available,
                                        options.source, options.check, config,
-                                       int(config.timeout)))
+                                       config.timeout))
 
         if options.source and len(results.results) == 0:
             for plugin in plugins:

--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -346,12 +346,6 @@ class RunChecks:
         if rval is not None:
             return rval
 
-        if options.verbose:
-            logger.setLevel(logging.INFO)
-
-        if options.debug:
-            logger.setLevel(logging.DEBUG)
-
         if options.config is not None:
             config = read_config(options.config)
         else:
@@ -365,6 +359,12 @@ class RunChecks:
         config.merge(vars(options))
         self.options = config
         options = config
+
+        if options.verbose:
+            logger.setLevel(logging.INFO)
+
+        if options.debug:
+            logger.setLevel(logging.DEBUG)
 
         # pylint: disable=assignment-from-none
         rval = self.pre_check()

--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -320,7 +320,7 @@ class RunChecks:
     def run_healthcheck(self):
         framework = object()
         plugins = []
-        output = constants.DEFAULT_OUTPUT
+        output = None
 
         logger.setLevel(logging.WARNING)
 
@@ -413,6 +413,9 @@ class RunChecks:
             if out.__name__.lower() == options.output_type:
                 output = out(options)
                 break
+        if output is None:
+            print(f"Unknown output-type '{options.output_type}'")
+            return 1
 
         if options.list_sources:
             return list_sources(plugins)

--- a/src/ipahealthcheck/core/output.py
+++ b/src/ipahealthcheck/core/output.py
@@ -111,7 +111,7 @@ class JSON(Output):
 
     def __init__(self, options):
         super().__init__(options)
-        self.indent = int(options.indent)
+        self.indent = options.indent
 
     def generate(self, data):
         output = json.dumps(data, indent=self.indent)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ import tempfile
 
 import pytest
 
-from ipahealthcheck.core.config import read_config
+from ipahealthcheck.core.config import read_config, convert_string
 
 
 def test_config_no_section():
@@ -59,3 +59,17 @@ def test_config_recursion():
         config._Config__d['_Config__d']
     except KeyError:
         pass
+
+
+def test_convert_string():
+    for value in ("s", "string", "BiggerString"):
+        assert convert_string(value) == value
+
+    for value in ("True", "true", True):
+        assert convert_string(value) is True
+
+    for value in ("False", "false", False):
+        assert convert_string(value) is False
+
+    for value in ("10", "99999", 807):
+        assert convert_string(value) == int(value)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -40,6 +40,6 @@ def test_options_merge(mock_parse, mock_run, mock_service):
 
         # verify two valus that have defaults with our overriden values
         assert run.options.output_type == 'human'
-        assert run.options.indent == '5'
+        assert run.options.indent == 5
     finally:
         os.remove(config_path)


### PR DESCRIPTION
Three small fixes to allowing the configuration file to set command-line options discovered by QE during review process