### PR TITLE
Verify that the number of KDC workers matches the CPUs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
             'ipadns = ipahealthcheck.ipa.idns',
             'ipafiles = ipahealthcheck.ipa.files',
             'ipahost = ipahealthcheck.ipa.host',
+            'ipakdc = ipahealthcheck.ipa.kdc',
             'ipaproxy = ipahealthcheck.ipa.proxy',
             'ipameta = ipahealthcheck.ipa.meta',
             'ipanss = ipahealthcheck.ipa.nss',

--- a/src/ipahealthcheck/ipa/kdc.py
+++ b/src/ipahealthcheck/ipa/kdc.py
@@ -1,0 +1,72 @@
+
+# Copyright (C) 2022 FreeIPA Contributors see COPYING for license
+#
+
+import logging
+import os
+
+from ipahealthcheck.ipa.plugin import IPAPlugin, registry
+from ipahealthcheck.core.plugin import Result, duration
+from ipahealthcheck.core import constants
+
+
+logger = logging.getLogger()
+SYSCONFIG = '/etc/sysconfig/krb5kdc'
+
+
+def get_contents(file):
+    with open(SYSCONFIG, "r") as fd:
+        lines = fd.readlines()
+    return lines
+
+
+@registry
+class KDCWorkersCheck(IPAPlugin):
+    """Verify that the number of workers matches the number of cores"""
+
+    @duration
+    def check(self):
+        key = 'workers'
+        cpus = os.sysconf('SC_NPROCESSORS_ONLN')
+        logging.debug('Detected %s CPUs', cpus)
+
+        lines = get_contents(SYSCONFIG)
+
+        args_read = False
+        for line in lines:
+            sline = line.strip()
+            workers = 0
+            if sline.startswith('KRB5KDC_ARGS'):
+                args_read = True
+                sline = sline.split('=', maxsplit=1)[1]
+                if sline.find("-w") == -1:
+                    yield Result(self, constants.WARNING, key=key,
+                                 sysconfig=SYSCONFIG,
+                                 msg='No KDC workers defined in '
+                                 '{sysconfig}')
+                    return
+
+                # Making an assumption that this line is not misconfigured
+                # otherwise the KDC wouldn't start at all.
+                sline = sline.replace("'", "")
+                sline = sline.replace('"', "")
+                sline = sline.split()
+                for i in range(len(sline)):
+                    if sline[i] == '-w':
+                        workers = int(sline[i+1])
+                        break
+                if cpus == workers:
+                    yield Result(self, constants.SUCCESS, key=key)
+                else:
+                    yield Result(self, constants.WARNING, key=key,
+                                 cpus=cpus, workers=workers,
+                                 sysconfig=SYSCONFIG,
+                                 msg='The number of CPUs {cpus} does not '
+                                     'match the number of workers '
+                                     '{workers} in {sysconfig}')
+                break
+        if not args_read:
+            yield Result(self, constants.WARNING, key=key,
+                         sysconfig=SYSCONFIG,
+                         msg='KRB5KDC_ARGS is not set in '
+                         '{sysconfig}')

--- a/tests/test_ipa_kdc.py
+++ b/tests/test_ipa_kdc.py
@@ -1,0 +1,101 @@
+#
+# Copyright (C) 2022 FreeIPA Contributors see COPYING for license
+#
+
+from base import BaseTest
+from unittest.mock import patch
+from util import capture_results
+
+from ipahealthcheck.core import config, constants
+from ipahealthcheck.ipa.plugin import registry
+from ipahealthcheck.ipa.kdc import KDCWorkersCheck
+
+
+class TestKDCWorkers(BaseTest):
+    @patch('ipahealthcheck.ipa.kdc.get_contents')
+    @patch('os.sysconf')
+    def test_no_workers(self, mock_sysconf, mock_sysconfig):
+        mock_sysconf.return_value = 1
+        mock_sysconfig.return_value = ""
+        framework = object()
+        registry.initialize(framework, config.Config)
+        f = KDCWorkersCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.WARNING
+        assert result.source == 'ipahealthcheck.ipa.kdc'
+        assert result.check == 'KDCWorkersCheck'
+        assert result.kw.get('key') == 'workers'
+        assert result.kw.get('sysconfig') == '/etc/sysconfig/krb5kdc'
+        assert result.kw.get('msg') == 'KRB5KDC_ARGS is not set in {sysconfig}'
+
+    @patch('ipahealthcheck.ipa.kdc.get_contents')
+    @patch('os.sysconf')
+    def test_workers_match_single(self, mock_sysconf, mock_sysconfig):
+        mock_sysconf.return_value = 1
+        mock_sysconfig.return_value = (
+            ("KRB5KDC_ARGS='-w 1'", "KRB5REALM=EXAMPLE.TEST")
+        )
+        framework = object()
+        registry.initialize(framework, config.Config)
+        f = KDCWorkersCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.kdc'
+        assert result.check == 'KDCWorkersCheck'
+        assert result.kw.get('key') == 'workers'
+
+    @patch('ipahealthcheck.ipa.kdc.get_contents')
+    @patch('os.sysconf')
+    def test_workers_match_double(self, mock_sysconf, mock_sysconfig):
+        mock_sysconf.return_value = 1
+        mock_sysconfig.return_value = (
+            ('KRB5KDC_ARGS="-w 1"', "KRB5REALM=EXAMPLE.TEST")
+        )
+        framework = object()
+        registry.initialize(framework, config.Config)
+        f = KDCWorkersCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.kdc'
+        assert result.check == 'KDCWorkersCheck'
+
+    @patch('ipahealthcheck.ipa.kdc.get_contents')
+    @patch('os.sysconf')
+    def test_workers_mismatch(self, mock_sysconf, mock_sysconfig):
+        mock_sysconf.return_value = 2
+        mock_sysconfig.return_value = (
+            ("KRB5KDC_ARGS='-w 1'", "KRB5REALM=EXAMPLE.TEST")
+        )
+        framework = object()
+        registry.initialize(framework, config.Config)
+        f = KDCWorkersCheck(registry)
+
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.WARNING
+        assert result.source == 'ipahealthcheck.ipa.kdc'
+        assert result.check == 'KDCWorkersCheck'
+        assert result.kw.get('key') == 'workers'
+        assert result.kw.get('cpus') == 2
+        assert result.kw.get('workers') == 1
+        assert result.kw.get("msg") == "The number of CPUs {cpus} " \
+                                       "does not match the number of " \
+                                       "workers {workers} in {sysconfig}"


### PR DESCRIPTION
Maximizing the number of workers improves scalability.

Particularly in VM environments the number can change over
time. The value is set at installation time but could change
later. Warn if they values don't match.

https://github.com/freeipa/freeipa-healthcheck/issues/258

Signed-off-by: Rob Crittenden <rcritten@redhat.com>