### PR TITLE
Tests: User to be warned about incorrect delimiter

### DIFF
--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -4,6 +4,7 @@
 
 import argparse
 import io
+import logging
 import os
 import tempfile
 from contextlib import redirect_stdout
@@ -101,6 +102,38 @@ def test_incorrect_output_type_cfg_file(mock_parse, mock_run, mock_service):
             run.run_healthcheck()
 
         assert "Unknown output-type" in f.getvalue()
+
+    finally:
+        os.remove(config_path)
+
+
+@patch('ipahealthcheck.core.core.run_service_plugins')
+@patch('ipahealthcheck.core.core.run_plugins')
+@patch('ipahealthcheck.core.core.parse_options')
+def test_incorrect_delimiter_cfg_file(mock_parse, mock_run, mock_service,
+                                      caplog):
+    """
+    Test the error message is user-friendly if the incorrect delimiter is
+    used in cfg file
+
+    Related: https://bugzilla.redhat.com/show_bug.cgi?id=2079739
+    """
+    mock_service.return_value = (Results(), [])
+    mock_run.return_value = Results()
+    mock_parse.return_value = options
+    fd, config_path = tempfile.mkstemp()
+    os.close(fd)
+    with open(config_path, "w") as fd:
+        fd.write('[default]\n')
+        fd.write('output_type;human\n')
+
+    try:
+        run = RunChecks([], config_path)
+
+        with caplog.at_level(logging.ERROR):
+            run.run_healthcheck()
+
+        assert "contains parsing errors" in caplog.text
 
     finally:
         os.remove(config_path)


### PR DESCRIPTION
Test if the error message is descriptive and informative when incorrect
delimiter is supplied in the configuration file.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2079739

Signed-off-by: Michal Polovka <mpolovka@redhat.com>