### PR TITLE
gha: Replace F34/35 with F35/36

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fedora-release: [34, 35]
+        fedora-release: [35, 36]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- dropping Fedora 34 because it is due to EOL soon

Signed-off-by: Rob Crittenden <rcritten@redhat.com>