### PR TITLE
kdc: Don't return a WARNING if there are no ARGS and cpus == 1

### DIFF
--- a/src/ipahealthcheck/ipa/kdc.py
+++ b/src/ipahealthcheck/ipa/kdc.py
@@ -40,11 +40,16 @@ class KDCWorkersCheck(IPAPlugin):
                 args_read = True
                 sline = sline.split('=', maxsplit=1)[1]
                 if sline.find("-w") == -1:
-                    yield Result(self, constants.WARNING, key=key,
-                                 sysconfig=SYSCONFIG,
-                                 msg='No KDC workers defined in '
-                                 '{sysconfig}')
-                    return
+                    if cpus == 1:
+                        # -w is not configured when cpus == 1
+                        yield Result(self, constants.SUCCESS, key=key)
+                        return
+                    else:
+                        yield Result(self, constants.WARNING, key=key,
+                                     sysconfig=SYSCONFIG,
+                                     msg='No KDC workers defined in '
+                                     '{sysconfig}')
+                        return
 
                 # Making an assumption that this line is not misconfigured
                 # otherwise the KDC wouldn't start at all.


### PR DESCRIPTION
If there is only a single CPU at installation time then
KRB5KDC_ARGS is nnot set and it may contain an empty value like:

KRB5KDC_ARSG=

Treat this as a successful execution.

Related: https://github.com/freeipa/freeipa-healthcheck/issues/258

Signed-off-by: Rob Crittenden <rcritten@redhat.com>