### PR TITLE
Add /run/ipa to the list of files/directories to check

### DIFF
--- a/src/ipahealthcheck/ipa/files.py
+++ b/src/ipahealthcheck/ipa/files.py
@@ -171,6 +171,12 @@ class IPAFileCheck(IPAPlugin, FileCheck):
                 constants.PKI_USER, constants.PKI_GROUP, '0640'
             ))
 
+        self.files.append((paths.IPA_CCACHES,
+                           constants.IPAAPI_USER, constants.IPAAPI_GROUP,
+                           '6770'))
+        self.files.append((paths.IPA_RENEWAL_LOCK, 'root', 'root', '0600'))
+        self.files.append((paths.SVC_LIST_FILE, 'root', 'root', '0644'))
+
         return FileCheck.check(self)
 
 


### PR DESCRIPTION
/run/ipa/ccaches is the main target, to ensure it retains the
right owner/group/permissions for privilege separation to work
by setting setuid and setgid so the underlying ccaches are
only readable by the ipaapi user/group.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/232

Signed-off-by: Rob Crittenden <rcritten@redhat.com>