### PR TITLE
Require root to run ipa-healthcheck

### DIFF
--- a/man/man8/ipa-healthcheck.8
+++ b/man/man8/ipa-healthcheck.8
@@ -10,6 +10,8 @@ ipa\-healthcheck [\fIOPTION\fR]...
 .SH "DESCRIPTION"
 An IPA installation is a complex system and identifying real or potential issues can be difficult and require a lot of analysis. This tool aims to reduce the burden of that and attempts to identify issues in advance so they can be corrected, ideally before the issue is critical.
 
+This tool must be run as root in order to access all components of a system.
+
 .SS "ORGANIZATION"
 These areas of the system to check can be logically grouped together. This grouping is called a source. A source consists of one or more checks.
 

--- a/src/ipahealthcheck/core/main.py
+++ b/src/ipahealthcheck/core/main.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2019 FreeIPA Contributors see COPYING for license
 #
 
-from os import environ
+import os
 import sys
 
 from ipahealthcheck.core import constants
@@ -43,8 +43,10 @@ class IPAChecks(RunChecks):
 
 
 def main():
-    environ["KRB5_CLIENT_KTNAME"] = "/etc/krb5.keytab"
-    environ["KRB5CCNAME"] = "MEMORY:"
+    if not os.getegid() == 0:
+        sys.exit("\nYou must be root to run this script.\n")
+    os.environ["KRB5_CLIENT_KTNAME"] = "/etc/krb5.keytab"
+    os.environ["KRB5CCNAME"] = "MEMORY:"
 
     ipachecks = IPAChecks(['ipahealthcheck.registry',
                            'pkihealthcheck.registry'],

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,6 +7,9 @@ import os
 from ipapython.ipautil import run
 import pytest
 
+if not os.getegid() == 0:
+    pytest.skip("must be run as root", allow_module_level=True)
+
 
 def test_version():
     """


### PR DESCRIPTION
The vast majority of checks require root access so enforce
it at run time.

This won't affect other runtimes that use healthcheck-core.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/148

Signed-off-by: Rob Crittenden <rcritten@redhat.com>