### PR TITLE
Use DN to compare agent cert issuer and subjects

### DIFF
--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -1021,7 +1021,16 @@ def check_agent(plugin, base_dn, agent_type):
             return
         ra_desc = raw_desc[0]
         ra_certs = entry.get('usercertificate')
-        if ra_desc != description:
+        (_version, exp_serial, exp_issuer, exp_subject) = \
+            ra_desc.split(';')
+        matched = all(
+            [
+                str(serial_number) == exp_serial,
+                DN(issuer) == DN(exp_issuer),
+                DN(subject) == DN(exp_subject),
+            ]
+        )
+        if not matched:
             yield Result(plugin, constants.ERROR,
                          key='description_mismatch',
                          expected=description,

--- a/tests/test_ipa_agent.py
+++ b/tests/test_ipa_agent.py
@@ -219,6 +219,30 @@ class TestNSSAgent(BaseTest):
         assert result.source == 'ipahealthcheck.ipa.certs'
         assert result.check == 'IPARAAgent'
 
+    def test_nss_agent_mixed_case_cert(self):
+        attrs = dict(
+            description=['2;1;cn=ISSUER;cn=RA AGENT'],
+            usercertificate=[self.cert],
+        )
+        fake_conn = LDAPClient('ldap://localhost', no_schema=True)
+        ldapentry = LDAPEntry(fake_conn, DN('uid=ipara,ou=people,o=ipaca'))
+        for attr, values in attrs.items():
+            ldapentry[attr] = values
+
+        framework = object()
+        registry.initialize(framework, config.Config)
+        f = IPARAAgent(registry)
+
+        f.conn = mock_ldap([ldapentry])
+        self.results = capture_results(f)
+
+        assert len(self.results) == 1
+
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
+        assert result.source == 'ipahealthcheck.ipa.certs'
+        assert result.check == 'IPARAAgent'
+
 
 class TestKRAAgent(BaseTest):
     cert = IPACertificate()


### PR DESCRIPTION
The comparison was doing a string compare of the expected
description value.  This worked most of the time but if there
were simple case differents in the attributes that would
cause a false failure.

Instead compare them separately using the DN class to do
the comparison.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/93

Signed-off-by: Rob Crittenden <rcritten@redhat.com>