### PR TITLE
Use new approach to validate whether the ipa-ca DNS record is complete

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -7,8 +7,9 @@ import json
 import logging
 import pkg_resources
 import signal
-import warnings
+import sys
 import traceback
+import warnings
 
 from datetime import datetime
 
@@ -244,8 +245,7 @@ def parse_options(parser):
 
     # Validation
     if options.check and not options.source:
-        print("--source is required when --check is used")
-        return 1
+        raise ValueError("--source is required when --check is used")
 
     return options
 
@@ -328,7 +328,10 @@ class RunChecks:
                             self.default_output)
         add_output_options(self.parser, self.output_registry)
         self.add_options()
-        options = parse_options(self.parser)
+        try:
+            options = parse_options(self.parser)
+        except ValueError as e:
+            sys.exit(str(e))
 
         if options.version:
             for registry in self.entry_points:


### PR DESCRIPTION
Related to the ticket:

    Use new approach to validate whether the ipa-ca DNS record is complete
    
    The previous method counted the number of servers with CA's and
    expected an identical count of servers in ipa-ca, for each of the
    A and AAAA types.
    
    If one server had only A or AAAA records then this count could be
    off and issue a spurious warning.
    
    Instead get the list of A and AAAA records for servers with a CA
    and compare the IP addresses to those of the A and AAAA records
    of ipa-ca. Return a warning if any are missing or not expected
    (e.g. a server was removed but remains in ipa-ca).
    
    https://github.com/freeipa/freeipa-healthcheck/issues/270
    
    Signed-off-by: Rob Crittenden <rcritten@redhat.com>

I ran into this while testing the above patch so went ahead and included the fix:

    Use exceptions to indicate parsing errors, not a return value
    
    The validation in parse_options() retured a 1 on failure.
    Raise an exception instead and expect the caller to handle it.
    
    Signed-off-by: Rob Crittenden <rcritten@redhat.com>
