### PR TITLE
Add limited support for CA certificates on a hardware token (HSM)

### DIFF
--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -5,6 +5,7 @@ from __future__ import division
 
 from datetime import datetime, timezone, timedelta
 import itertools
+from inspect import signature
 import logging
 import os
 import socket
@@ -79,6 +80,14 @@ def get_expected_requests(ca, ds, serverid):
             dogtag_reqs = itertools.chain(dogtag_reqs,
                                           kra.tracking_reqs.items())
         for nick, profile in dogtag_reqs:
+            if profile in ('caSignedLogCert', 'caOCSPCert',
+                           'caSubsystemCert', 'caCACert',
+                           'caAuditSigningCert', 'caTransportCert',
+                           'caStorageCert'):
+                token = ca.token_name
+            else:
+                token = None
+
             req = {
                 'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,
                 'cert-nickname': nick,
@@ -88,6 +97,8 @@ def get_expected_requests(ca, ds, serverid):
                     (template % 'renew_ca_cert "{}"'.format(nick)),
                 'template-profile': profile,
             }
+            if token and token != 'internal':
+                req['key-token'] = token
             requests.append(req)
     else:
         logger.debug('CA is not configured, skipping CA tracking')
@@ -164,6 +175,44 @@ def get_expected_requests(ca, ds, serverid):
             )
 
     return requests
+
+
+def expected_token(token_name, certmonger_token):
+    """The value is stored in two places, do some sanity checking"""
+    if token_name != str(certmonger_token):
+        logger.debug(
+            f"The IPA token {token_name} doesn't match the certmonger "
+            f"token {certmonger_token}."
+        )
+        return False
+
+    return True
+
+
+def get_token_password(hsm_enabled, token):
+    if not hsm_enabled:
+        return None
+
+    with open(paths.PKI_TOMCAT_PASSWORD_CONF, "r") as passfile:
+        contents = passfile.readlines()
+
+    for line in contents:
+        data = line.split('=', 1)
+        if data[0] == 'hardware-' + token:
+            return data[1]
+
+    return None
+
+
+def get_token_password_file(hsm_enabled, token):
+    """The CA contains the list of HSM passwords, find ours"""
+    pwdfile = None
+    token_pw = get_token_password(hsm_enabled, token)
+
+    if hsm_enabled and token_pw:
+        pwdfile = ipautil.write_tmp_file(token_pw)
+
+    return pwdfile
 
 
 def get_dogtag_cert_password():
@@ -280,11 +329,24 @@ class IPACertfileExpirationCheck(IPAPlugin):
                                      'file \'{certfile}\': {error}')
                     continue
             elif store == 'NSSDB':
+                token = request.prop_if.Get(certmonger.DBUS_CM_REQUEST_IF,
+                                            'key-token')
                 nickname = str(request.prop_if.Get(
                                certmonger.DBUS_CM_REQUEST_IF, 'key_nickname'))
+                if token and expected_token(self.ca.token_name, token):
+                    nickname = '{}:{}'.format(token, nickname)
                 dbdir = str(request.prop_if.Get(
                             certmonger.DBUS_CM_REQUEST_IF, 'cert_database'))
+
+                pwd_file = get_token_password_file(self.ca.hsm_enabled,
+                                                   token)
+
                 try:
+                    db = certdb.NSSDatabase(
+                        dbdir, token=token,
+                        pwd_file=pwd_file.name if pwd_file else None)
+                except TypeError:
+                    # Fall back to older API
                     db = certdb.NSSDatabase(dbdir)
                 except Exception as e:
                     yield Result(self, constants.ERROR,
@@ -525,31 +587,50 @@ class IPACertDNSSAN(IPAPlugin):
 @registry
 class IPACertNSSTrust(IPAPlugin):
     """Compare the NSS trust for the CA certs to a known good value"""
+
     @duration
     def check(self):
+        if not self.ca.is_configured():
+            logger.debug('CA is not configured, skipping NSS trust check')
+            return
+
+        if self.ca.hsm_enabled:
+            token = self.ca.token_name + ":"
+        else:
+            token = ""
+
         expected_trust = {
-            'ocspSigningCert cert-pki-ca': 'u,u,u',
-            'subsystemCert cert-pki-ca': 'u,u,u',
-            'auditSigningCert cert-pki-ca': 'u,u,Pu',
+            f'{token}ocspSigningCert cert-pki-ca': 'u,u,u',
+            f'{token}subsystemCert cert-pki-ca': 'u,u,u',
+            f'{token}auditSigningCert cert-pki-ca': 'u,u,Pu',
             'Server-Cert cert-pki-ca': 'u,u,u',
         }
         kra = krainstance.KRAInstance(api.env.realm)
         if kra.is_installed():
             kra_trust = {
-                'transportCert cert-pki-kra': 'u,u,u',
-                'storageCert cert-pki-kra': 'u,u,u',
-                'auditSigningCert cert-pki-kra': 'u,u,Pu',
+                f'{token}transportCert cert-pki-kra': 'u,u,u',
+                f'{token}storageCert cert-pki-kra': 'u,u,u',
+                f'{token}auditSigningCert cert-pki-kra': 'u,u,Pu',
             }
             expected_trust.update(kra_trust)
 
-        if not self.ca.is_configured():
-            logger.debug('CA is not configured, skipping NSS trust check')
-            return
+        db = certdb.NSSDatabase(paths.PKI_TOMCAT_ALIAS_DIR)
+        certlist = db.list_certs()
+        if token:
+            token = token[:-1]  # Strip off trailing colon
 
-        db = certs.CertDB(api.env.realm, paths.PKI_TOMCAT_ALIAS_DIR)
-        for nickname, _trust_flags in db.list_certs():
+            pwd_file = get_token_password_file(self.ca.hsm_enabled,
+                                               token)
+
+            db = certdb.NSSDatabase(
+                paths.PKI_TOMCAT_ALIAS_DIR, token=token,
+                pwd_file=pwd_file.name if pwd_file else None)
+
+            certlist += db.list_certs()
+
+        for nickname, _trust_flags in certlist:
             flags = certdb.unparse_trust_flags(_trust_flags)
-            if nickname.startswith('caSigningCert cert-pki-ca'):
+            if nickname == f'{token}caSigningCert cert-pki-ca':
                 expected = 'CTu,Cu,Cu'
             else:
                 try:
@@ -706,7 +787,7 @@ class IPADogtagCertsMatchCheck(IPAPlugin):
     @duration
     def check(self):
         if not self.ca.is_configured():
-            logger.debug('CA is not configured, skipping connectivity check')
+            logger.debug('CA is not configured, skipping match check')
             return
 
         def match_ldap_nss_cert(plugin, ldap, db, cert_dn, attr, cert_nick):
@@ -761,9 +842,20 @@ class IPADogtagCertsMatchCheck(IPAPlugin):
                                       '{dbdir} does not match entry in LDAP'))
             return all_ok
 
-        db = certs.CertDB(api.env.realm, paths.PKI_TOMCAT_ALIAS_DIR)
+        if self.ca.hsm_enabled:
+            token = self.ca.token_name + ':'
+        else:
+            token = ''
+        pwd_file = get_token_password_file(self.ca.hsm_enabled,
+                                           self.ca.token_name)
+        if 'pwd_file' in signature(certs.CertDB).parameters:
+            db = certs.CertDB(api.env.realm, paths.PKI_TOMCAT_ALIAS_DIR,
+                              pwd_file=pwd_file.name if pwd_file else None)
+        else:
+            # Fall back to older API
+            db = certs.CertDB(api.env.realm, paths.PKI_TOMCAT_ALIAS_DIR)
         dn = DN('uid=pkidbuser,ou=people,o=ipaca')
-        subsystem_nick = 'subsystemCert cert-pki-ca'
+        subsystem_nick = f'{token}subsystemCert cert-pki-ca'
         subsystem_ok = yield from match_ldap_nss_cert(self, self.conn,
                                                       db, dn,
                                                       'userCertificate',
@@ -771,7 +863,7 @@ class IPADogtagCertsMatchCheck(IPAPlugin):
         dn = DN('cn=%s IPA CA' % api.env.realm,
                 'cn=certificates,cn=ipa,cn=etc',
                 api.env.basedn)
-        casigning_nick = 'caSigningCert cert-pki-ca'
+        casigning_nick = f'{token}caSigningCert cert-pki-ca'
         casigning_ok = yield from match_ldap_nss_cert(self, self.conn,
                                                       db, dn, 'CACertificate',
                                                       casigning_nick)
@@ -779,11 +871,11 @@ class IPADogtagCertsMatchCheck(IPAPlugin):
         config = api.Command.config_show()
         subject_base = config['result']['ipacertificatesubjectbase'][0]
         expected_nicks_subjects = {
-            'ocspSigningCert cert-pki-ca':
+            f'{token}ocspSigningCert cert-pki-ca':
                 f'CN=OCSP Subsystem,{subject_base}',
-            'subsystemCert cert-pki-ca':
+            f'{token}subsystemCert cert-pki-ca':
                 f'CN=CA Subsystem,{subject_base}',
-            'auditSigningCert cert-pki-ca':
+            f'{token}auditSigningCert cert-pki-ca':
                 f'CN=CA Audit,{subject_base}',
             'Server-Cert cert-pki-ca':
                 f'CN={api.env.host},{subject_base}',
@@ -792,11 +884,11 @@ class IPADogtagCertsMatchCheck(IPAPlugin):
         kra = krainstance.KRAInstance(api.env.realm)
         if kra.is_installed():
             kra_expected_nicks_subjects = {
-                'transportCert cert-pki-kra':
+                f'{token}transportCert cert-pki-kra':
                     f'CN=KRA Transport Certificate,{subject_base}',
-                'storageCert cert-pki-kra':
+                f'{token}storageCert cert-pki-kra':
                     f'CN=KRA Storage Certificate,{subject_base}',
-                'auditSigningCert cert-pki-kra':
+                f'{token}auditSigningCert cert-pki-kra':
                     f'CN=KRA Audit,{subject_base}',
             }
             expected_nicks_subjects.update(kra_expected_nicks_subjects)
@@ -1131,6 +1223,8 @@ class IPACertRevocation(IPAPlugin):
             logger.debug('CA is not configured, skipping revocation check')
             return
         requests = get_expected_requests(self.ca, self.ds, self.serverid)
+        pwd_file = get_token_password_file(self.ca.hsm_enabled,
+                                           self.ca.token_name)
         for request in requests:
             id = certmonger.get_request_id(request)
             if request.get('cert-file') is not None:
@@ -1147,8 +1241,17 @@ class IPACertRevocation(IPAPlugin):
                     continue
             elif request.get('cert-database') is not None:
                 nickname = request.get('cert-nickname')
+                token = request.get('key-token')
+                if token == 'internal':
+                    token = None
                 dbdir = request.get('cert-database')
                 try:
+                    db = certdb.NSSDatabase(
+                        dbdir, token=token,
+                        pwd_file=pwd_file.name if pwd_file else None
+                    )
+                except TypeError:
+                    # fall back to older API that doesn't support tokens
                     db = certdb.NSSDatabase(dbdir)
                 except Exception as e:
                     yield Result(self, constants.ERROR,
@@ -1158,6 +1261,8 @@ class IPACertRevocation(IPAPlugin):
                                  msg='Unable to open NSS database {dbdir}: '
                                      '{error}')
                     continue
+                if token:
+                    nickname = f'{token}:{nickname}'
                 try:
                     cert = db.get_cert(nickname)
                 except Exception as e:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -33,4 +33,4 @@ def test_Registry():
 
     # Test registration
     names = [plugin.__class__.__name__ for plugin in r.get_plugins()]
-    assert(names == ['plugin1', 'plugin2'])
+    assert (names == ['plugin1', 'plugin2'])

--- a/tests/util.py
+++ b/tests/util.py
@@ -46,13 +46,32 @@ def capture_results(f):
     return results
 
 
-class CAInstance:
+class DogtagInstance:
+    def __init__(self, hsm_enabled=False, token_name=None):
+        self.hsmenabled = hsm_enabled
+        self.tokenname = token_name
+
+    @property
+    def hsm_enabled(self):
+        """Is HSM support enabled?"""
+        return self.hsmenabled
+
+    @property
+    def token_name(self):
+        """HSM token name"""
+        return self.tokenname
+
+
+class CAInstance(DogtagInstance):
     """A bare-bones CAinistance override
 
        This is needed to control whether the underlying master is
        CAless or CAful.
     """
-    def __init__(self, enabled=True, crlgen=True):
+    def __init__(self, enabled=True, crlgen=True, hsm_enabled=False,
+                 token=None):
+        super(CAInstance, self).__init__(hsm_enabled=hsm_enabled,
+                                         token_name=token)
         self.enabled = enabled
         self.crlgen = crlgen
 
@@ -63,7 +82,7 @@ class CAInstance:
         return self.crlgen
 
 
-class KRAInstance:
+class KRAInstance(DogtagInstance):
     """A bare-bones KRAinistance override
 
        This is needed to control whether the underlying master is


### PR DESCRIPTION
dogtagpki supports storing its subsystem and CA certificates on an HSM. Look up the token name and password in the NSS db password file. If a token exists then include that in the lookup and expect (require) the CA, audit, ocsp and subsystem certificates to be there. If a KRA is also configured then those certificates will be in the HSM as well.

PKI supports mixing and matching but for now this only supports a simplistic one HSM or no HSM.

This requires an update to IPA where certificates can be looked up by token. At this point HSM is not yet supported in IPA but once it is then this will just work.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/276

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

Validating this is tricky without an HSM-enabled IPA which isn't yet available outside of my workstation... Best you can do is verify this causes no harm.