### PR TITLE
Report certmonger requests that are in the stuck state

### DIFF
--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -1418,3 +1418,22 @@ class IPACAChainExpirationCheck(IPAPlugin):
                              path=paths.IPA_CA_CRT,
                              key=subject,
                              days=(dt - now).days)
+
+
+@registry
+class CertmongerStuckCheck(IPAPlugin):
+    """Check for certonger requests in the stuck state
+    """
+
+    @duration
+    def check(self):
+        requests = certmonger._get_requests({'stuck': True})
+        for request in requests:
+            id = request.prop_if.Get(certmonger.DBUS_CM_REQUEST_IF, 'nickname')
+            yield Result(self, constants.WARNING,
+                         key=id,
+                         msg='certmonger request {key} is in the '
+                         'stuck state')
+
+        if len(requests) == 0:
+            yield Result(self, constants.SUCCESS, key='no_stuck')


### PR DESCRIPTION
These may be caught already by other checks if the tracking is configured incorrectly but it's a belt-and-suspenders approach to ensure that the certificates have been issued properly.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/123