### PR TITLE
output: fix prometheus output pluging to comply with format spec

### DIFF
--- a/tests/fixtures/output/prometheus/all.prom
+++ b/tests/fixtures/output/prometheus/all.prom
@@ -1,0 +1,4 @@
+# HELP test_healthcheck Number of healthchecks with a certain result
+# TYPE test_healthcheck gauge
+test_healthcheck{result="SUCCESS"} 1.0
+

--- a/tests/test_output_prometheus.py
+++ b/tests/test_output_prometheus.py
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2019 FreeIPA Contributors see COPYING for license
+#
+
+import pytest
+from util import assert_fixture
+
+from ipahealthcheck.core import constants
+from ipahealthcheck.core.output import Prometheus
+from ipahealthcheck.core.plugin import Plugin, Registry, Result, Results
+
+
+class OutputOptions:
+    def __init__(self):
+        self.__dict__ = {
+            'all': True,
+            'failures_only': False,
+            'severity': None,
+            'output_file': None,
+            'metric_prefix': 'test',
+        }
+
+    def __iter__(self):
+        return iter(self.__dict__)
+
+
+@pytest.fixture
+def check_results():
+    registry = Registry()
+    p = Plugin(registry)
+    r = Result(p, constants.SUCCESS)
+    f = Results()
+
+    f.add(r)
+
+    return f
+
+
+@pytest.fixture
+def output_options():
+    o = OutputOptions()
+
+    return o
+
+
+def test_Prometheus(output_options, check_results, capsys):
+    """
+    Test the `ipahealthcheck.core.Prometheus` class
+    """
+
+    # Create an output
+    p = Prometheus(output_options)
+
+    p.render(check_results)
+
+    captured = capsys.readouterr()
+
+    assert_fixture(captured.out, 'output', 'prometheus', 'all.prom')

--- a/tests/util.py
+++ b/tests/util.py
@@ -6,6 +6,7 @@ from ipahealthcheck.core.plugin import Results
 from unittest.mock import patch, Mock
 import ipalib
 from ipapython.dn import DN
+from os import path
 
 
 class ExceptionNotRaised(Exception):
@@ -151,3 +152,24 @@ def no_exceptions(results):
     """Given Results ensure that an except was not raised"""
     for result in results.results:
         assert 'exception' not in result.kw
+
+
+def assert_fixture(output, *segments):
+    fixture_root = path.dirname(__file__)
+    fixture_path = [fixture_root, 'fixtures']
+    fixture_name = path.join(*segments)
+    fixture_path.append(fixture_name)
+    fixture_file = path.join(*fixture_path)
+    subject = output.split("\n")
+    position = 0
+    with open(fixture_file) as fixture:
+        for line in fixture:
+            assert position < len(subject)
+
+            want = line.rstrip()
+            got = subject[position]
+            position += 1
+            context = 'Mismatch in %s@%d: %s' % (fixture_name, position, got)
+            assert got == want, context
+
+    assert position == len(subject)


### PR DESCRIPTION
use comment syntax for HELP and TYPE annotations, as specified by the prometheus test-base exposition format [1].

this change also introduces a output sub-class to reduce code duplication.

closes #292

[1] https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format