### PR TITLE
Python 3.12: utcnow function is deprecated

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -11,7 +11,7 @@ import sys
 import traceback
 import warnings
 
-from datetime import datetime
+from datetime import datetime, UTC
 
 from ipahealthcheck.core.config import read_config
 from ipahealthcheck.core.exceptions import TimeoutError
@@ -49,7 +49,7 @@ def run_plugin(plugin, available=(), timeout=constants.DEFAULT_TIMEOUT):
         raise TimeoutError('Request timed out')
 
     # manually calculate duration when we create results of our own
-    start = datetime.utcnow()
+    start = datetime.now(tz=UTC)
     signal.signal(signal.SIGALRM, signal_handler)
     signal.alarm(timeout)
     try:

--- a/src/ipahealthcheck/core/plugin.py
+++ b/src/ipahealthcheck/core/plugin.py
@@ -3,7 +3,7 @@
 #
 
 import uuid
-from datetime import datetime
+from datetime import datetime, UTC
 from functools import wraps
 
 from ipahealthcheck.core.constants import getLevelName, getLevel
@@ -13,10 +13,10 @@ def duration(f):
     """Compute the duration of execution"""
     @wraps(f)
     def wrapper(*args, **kwds):
-        start = datetime.utcnow()
+        start = datetime.now(tz=UTC)
         end = None
         for result in f(*args, **kwds):
-            end = datetime.utcnow()
+            end = datetime.now(tz=UTC)
             dur = end - start
             result.duration = '%6.6f' % dur.total_seconds()
             yield result
@@ -132,7 +132,7 @@ class Result:
                  start=None, duration=None, when=None, **kw):
         self.result = result
         self.kw = kw
-        self.when = when or generalized_time(datetime.utcnow())
+        self.when = when or generalized_time(datetime.now(UTC))
         self.duration = duration
         self.uuid = str(uuid.uuid4())
         if None not in (check, source):
@@ -144,7 +144,7 @@ class Result:
             self.check = plugin.__class__.__name__
             self.source = plugin.__class__.__module__
         if start is not None:
-            dur = datetime.utcnow() - start
+            dur = datetime.now(tz=UTC) - start
             self.duration = '%6.6f' % dur.total_seconds()
 
         assert getLevelName(result) is not None

--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -3,7 +3,7 @@
 #
 from __future__ import division
 
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone, timedelta, UTC
 import itertools
 from inspect import signature
 import logging
@@ -378,8 +378,9 @@ class IPACertfileExpirationCheck(IPAPlugin):
                                  'storage type: {store}')
                 continue
 
-            now = datetime.utcnow()
-            notafter = cert.not_valid_after
+            now = datetime.now(tz=UTC)
+            # Older versions of IPA provide naive timestamps
+            notafter = cert.not_valid_after.replace(tzinfo=UTC)
 
             if now > notafter:
                 yield Result(self, constants.ERROR,

--- a/tests/test_ipa_certfile_expiration.py
+++ b/tests/test_ipa_certfile_expiration.py
@@ -15,7 +15,7 @@ from mock_certmonger import (
     CERT_EXPIRATION_DAYS,
 )
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 
 class IPACertificate:
@@ -40,7 +40,7 @@ class TestIPACertificateFile(BaseTest):
     def test_certfile_expiration(self, mock_load_cert):
         set_requests(remove=1)
 
-        cert = IPACertificate(not_valid_after=datetime.utcnow() +
+        cert = IPACertificate(not_valid_after=datetime.now(tz=UTC) +
                               timedelta(days=CERT_EXPIRATION_DAYS))
         mock_load_cert.return_value = cert
 
@@ -63,7 +63,7 @@ class TestIPACertificateFile(BaseTest):
     def test_certfile_expiration_warning(self, mock_load_cert):
         set_requests(remove=1)
 
-        cert = IPACertificate(not_valid_after=datetime.utcnow() +
+        cert = IPACertificate(not_valid_after=datetime.now(tz=UTC) +
                               timedelta(days=7))
         mock_load_cert.return_value = cert
 
@@ -87,7 +87,7 @@ class TestIPACertificateFile(BaseTest):
     def test_certfile_expiration_expired(self, mock_load_cert):
         set_requests(remove=1)
 
-        cert = IPACertificate(not_valid_after=datetime.utcnow() +
+        cert = IPACertificate(not_valid_after=datetime.now(tz=UTC) +
                               timedelta(days=-100))
         mock_load_cert.return_value = cert
 


### PR DESCRIPTION
ipa-healthcheck on python 3.12 uses datetime.utcnow() which is deprecated and produces warnings.
Replace with datetime.now(tz=UTC)

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/298