### PR TITLE
Use timezone.utc instead of datetime.UTC for backwards compatibility

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -11,7 +11,7 @@ import sys
 import traceback
 import warnings
 
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 
 from ipahealthcheck.core.config import read_config
 from ipahealthcheck.core.exceptions import TimeoutError
@@ -49,7 +49,7 @@ def run_plugin(plugin, available=(), timeout=constants.DEFAULT_TIMEOUT):
         raise TimeoutError('Request timed out')
 
     # manually calculate duration when we create results of our own
-    start = datetime.now(tz=UTC)
+    start = datetime.now(tz=timezone.utc)
     signal.signal(signal.SIGALRM, signal_handler)
     signal.alarm(timeout)
     try:

--- a/src/ipahealthcheck/core/plugin.py
+++ b/src/ipahealthcheck/core/plugin.py
@@ -3,7 +3,7 @@
 #
 
 import uuid
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from functools import wraps
 
 from ipahealthcheck.core.constants import getLevelName, getLevel
@@ -13,10 +13,10 @@ def duration(f):
     """Compute the duration of execution"""
     @wraps(f)
     def wrapper(*args, **kwds):
-        start = datetime.now(tz=UTC)
+        start = datetime.now(tz=timezone.utc)
         end = None
         for result in f(*args, **kwds):
-            end = datetime.now(tz=UTC)
+            end = datetime.now(tz=timezone.utc)
             dur = end - start
             result.duration = '%6.6f' % dur.total_seconds()
             yield result
@@ -132,7 +132,7 @@ class Result:
                  start=None, duration=None, when=None, **kw):
         self.result = result
         self.kw = kw
-        self.when = when or generalized_time(datetime.now(UTC))
+        self.when = when or generalized_time(datetime.now(timezone.utc))
         self.duration = duration
         self.uuid = str(uuid.uuid4())
         if None not in (check, source):
@@ -144,7 +144,7 @@ class Result:
             self.check = plugin.__class__.__name__
             self.source = plugin.__class__.__module__
         if start is not None:
-            dur = datetime.now(tz=UTC) - start
+            dur = datetime.now(tz=timezone.utc) - start
             self.duration = '%6.6f' % dur.total_seconds()
 
         assert getLevelName(result) is not None

--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -3,7 +3,7 @@
 #
 from __future__ import division
 
-from datetime import datetime, timezone, timedelta, UTC
+from datetime import datetime, timezone, timedelta
 import itertools
 from inspect import signature
 import logging
@@ -378,9 +378,9 @@ class IPACertfileExpirationCheck(IPAPlugin):
                                  'storage type: {store}')
                 continue
 
-            now = datetime.now(tz=UTC)
+            now = datetime.now(tz=timezone.utc)
             # Older versions of IPA provide naive timestamps
-            notafter = cert.not_valid_after.replace(tzinfo=UTC)
+            notafter = cert.not_valid_after.replace(tzinfo=timezone.utc)
 
             if now > notafter:
                 yield Result(self, constants.ERROR,

--- a/tests/test_ipa_certfile_expiration.py
+++ b/tests/test_ipa_certfile_expiration.py
@@ -15,7 +15,7 @@ from mock_certmonger import (
     CERT_EXPIRATION_DAYS,
 )
 
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta, timezone
 
 
 class IPACertificate:
@@ -40,7 +40,7 @@ class TestIPACertificateFile(BaseTest):
     def test_certfile_expiration(self, mock_load_cert):
         set_requests(remove=1)
 
-        cert = IPACertificate(not_valid_after=datetime.now(tz=UTC) +
+        cert = IPACertificate(not_valid_after=datetime.now(tz=timezone.utc) +
                               timedelta(days=CERT_EXPIRATION_DAYS))
         mock_load_cert.return_value = cert
 
@@ -63,7 +63,7 @@ class TestIPACertificateFile(BaseTest):
     def test_certfile_expiration_warning(self, mock_load_cert):
         set_requests(remove=1)
 
-        cert = IPACertificate(not_valid_after=datetime.now(tz=UTC) +
+        cert = IPACertificate(not_valid_after=datetime.now(tz=timezone.utc) +
                               timedelta(days=7))
         mock_load_cert.return_value = cert
 
@@ -87,7 +87,7 @@ class TestIPACertificateFile(BaseTest):
     def test_certfile_expiration_expired(self, mock_load_cert):
         set_requests(remove=1)
 
-        cert = IPACertificate(not_valid_after=datetime.now(tz=UTC) +
+        cert = IPACertificate(not_valid_after=datetime.now(tz=timezone.utc) +
                               timedelta(days=-100))
         mock_load_cert.return_value = cert
 


### PR DESCRIPTION
We switched to datetime.UTC because datetime.utcnow() was deprecated. This is only available in python 3.11+. Use datetime.timezone.utc instead which is available from python 3.2+

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/302