### PR TITLE
Change the github runners to conform with new requirements

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
         fedora-release: [37, 38]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Lint with pylint fedora:${{ matrix.fedora-release }}
       run: |
         docker pull fedora:${{ matrix.fedora-release }}


### PR DESCRIPTION
The older style runner is being deprecreated per
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/