### PR TITLE
Support validating LWCA certmonger requests

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -10,6 +10,7 @@ import signal
 import sys
 import traceback
 import warnings
+from ipalib import api
 
 from datetime import datetime, timezone
 
@@ -464,6 +465,7 @@ class RunChecks:
             return 1
 
         results = exclude_keys(config, results)
+        api.Backend.ldap2.disconnect()
 
         try:
             output.render(results)

--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -1348,8 +1348,7 @@ class IPACertRevocation(IPAPlugin):
 
             # Now we have the cert either way, check the recovation
             try:
-                result = api.Command.cert_show(cert.serial_number,
-                                               all=True)
+                result = api.Command.cert_show(cert.serial_number)
             except Exception as e:
                 yield Result(self, constants.ERROR,
                              key=id,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -40,6 +40,9 @@ def python_ipalib_dir(tmpdir):
     return _make_facts
 
 
+@pytest.mark.xfail(
+    reason="https://github.com/freeipa/freeipa-healthcheck/issues/309"
+)
 def test_ipa_notinstalled(python_ipalib_dir, monkeypatch):
     """
     Test ipa-healthcheck handles the missing IPA stuff
@@ -47,9 +50,16 @@ def test_ipa_notinstalled(python_ipalib_dir, monkeypatch):
     monkeypatch.setenv("PYTHONPATH", python_ipalib_dir(configured=None))
     output = run(["ipa-healthcheck"], raiseonerr=False, env=os.environ)
     assert output.returncode == 1
-    assert "IPA server is not installed" in output.raw_output.decode("utf-8")
+    assert "IPA server is not installed" in output.raw_output.decode(
+        "utf-8"
+    ) or "IPA server is not installed" in output.raw_error_output.decode(
+        "utf-8"
+    )
 
 
+@pytest.mark.xfail(
+    reason="https://github.com/freeipa/freeipa-healthcheck/issues/309"
+)
 def test_ipa_unconfigured(python_ipalib_dir, monkeypatch):
     """
     Test ipa-healthcheck handles the unconfigured IPA server
@@ -57,4 +67,8 @@ def test_ipa_unconfigured(python_ipalib_dir, monkeypatch):
     monkeypatch.setenv("PYTHONPATH", python_ipalib_dir(configured=False))
     output = run(["ipa-healthcheck"], raiseonerr=False, env=os.environ)
     assert output.returncode == 1
-    assert "IPA server is not configured" in output.raw_output.decode("utf-8")
+    assert "IPA server is not configured" in output.raw_output.decode(
+        "utf-8"
+    ) or "IPA server is not configured" in output.raw_error_output.decode(
+        "utf-8"
+    )


### PR DESCRIPTION
The LWCA ids are UUID4 format and are stored in LDAP so we can retrieve the list (ignoring the ipa entry) and construct what the request should look like.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/307