### PR TITLE
Remove call to api.Backend.ldap2.disconnect()

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -10,7 +10,6 @@ import signal
 import sys
 import traceback
 import warnings
-from ipalib import api
 
 from datetime import datetime, timezone
 
@@ -465,7 +464,6 @@ class RunChecks:
             return 1
 
         results = exclude_keys(config, results)
-        api.Backend.ldap2.disconnect()
 
         try:
             output.render(results)


### PR DESCRIPTION
This was added while I was testing the IPA LDAP client cache performance. By disconnecting a summary of the cache is logged. I never intended it remain in the code.