### PR TITLE
Address two issues uncovered in freeIPA CI

### DIFF
--- a/src/ipahealthcheck/meta/services.py
+++ b/src/ipahealthcheck/meta/services.py
@@ -25,10 +25,18 @@ class IPAServiceCheck(ServiceCheck):
     def get_service_name(self, role):
         """Roles define broad services. Translate a role name into
            an individual service name.
+
+           Returns a string on success, None if the service is not
+           configured or cannot be determined.
         """
         conn = api.Backend.ldap2
-        if not api.Backend.ldap2.isconnected():
-            api.Backend.ldap2.connect()
+        try:
+            if not api.Backend.ldap2.isconnected():
+                api.Backend.ldap2.connect()
+        except errors.NetworkError:
+            logger.debug("Service '%s' is not running", self.service_name)
+            return None
+
         dn = DN(
             ("cn", role), ("cn", api.env.host),
             ("cn", "masters"), ("cn", "ipa"), ("cn", "etc"),

--- a/src/ipahealthcheck/meta/services.py
+++ b/src/ipahealthcheck/meta/services.py
@@ -203,20 +203,6 @@ class ods_enforcerd(IPAServiceCheck):
 
 
 @registry
-class ipa_ods_exporter(IPAServiceCheck):
-    requires = ('dirsrv',)
-
-    def check(self, instance=''):
-        self.service_name = self.get_service_name('DNSKeyExporter')
-
-        if self.service_name is None:
-            # No service name means it is not configured
-            return ()
-
-        return super().check()
-
-
-@registry
 class ipa_dnskeysyncd(IPAServiceCheck):
     requires = ('dirsrv',)
 


### PR DESCRIPTION
Temporarily disable the ipa-ods-exporter service status check
    
There is a bug in this service such that it will almost always
report as down. Rather than spamming users with this error give
time for it to be fixed in IPA upstream.
    
See https://pagure.io/freeipa/issue/9463

Don't fail if a service name cannot be looked up in LDAP
    
A new method was introduced to handle more IPA services. This
requires looking some of them up in LDAP. dirsrv not running
was not being caught so raised an error instead.
