### PR TITLE
Fixes log file permissions as per CIS benchmark

### DIFF
--- a/src/ipahealthcheck/ipa/files.py
+++ b/src/ipahealthcheck/ipa/files.py
@@ -121,7 +121,7 @@ class IPAFileCheck(IPAPlugin, FileCheck):
                 self.files.append((filename, 'root', 'root', '0600'))
 
         self.files.append((paths.IPA_CUSTODIA_AUDIT_LOG,
-                          'root', 'root', '0644'))
+                          'root', 'root', '0644', '0640'))
 
         self.files.append((paths.KADMIND_LOG, 'root', 'root',
                           ('0600', '0640')))
@@ -133,11 +133,13 @@ class IPAFileCheck(IPAPlugin, FileCheck):
         self.files.append((paths.SLAPD_INSTANCE_ERROR_LOG_TEMPLATE % inst,
                            constants.DS_USER, constants.DS_GROUP, '0600'))
 
-        self.files.append((paths.VAR_LOG_HTTPD_ERROR, 'root', 'root', '0644'))
+        self.files.append((paths.VAR_LOG_HTTPD_ERROR, 'root', 'root',
+                           '0644', '0640'))
 
         for globpath in glob.glob("%s/debug*.log" % paths.TOMCAT_CA_DIR):
             self.files.append(
-                (globpath, constants.PKI_USER, constants.PKI_GROUP, "0644")
+                (globpath, constants.PKI_USER, constants.PKI_GROUP,
+                 "0644", "0640")
             )
 
         for globpath in glob.glob(


### PR DESCRIPTION
As per CIS benchmark the log file permissions should be 640 for some log files but if we change /var/log/ipa-custodia.audit.log permissions to 640 then "ipa-healthcheck" reports a permission issue.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/325