### PR TITLE
Handle CS.cfg file missing in DogtagCertsConfigCheck

### DIFF
--- a/src/ipahealthcheck/dogtag/ca.py
+++ b/src/ipahealthcheck/dogtag/ca.py
@@ -3,6 +3,7 @@
 #
 
 import logging
+import os
 
 from ipahealthcheck.dogtag.plugin import DogtagPlugin, registry
 from ipahealthcheck.core.plugin import Result
@@ -30,6 +31,15 @@ class DogtagCertsConfigCheck(DogtagPlugin):
     def check(self):
         if not self.ca.is_configured():
             logger.debug("No CA configured, skipping dogtag config check")
+            return
+
+        if not os.path.exists(paths.CA_CS_CFG_PATH):
+            yield Result(
+                self, constants.CRITICAL,
+                key=f'{paths.CA_CS_CFG_PATH}_missing',
+                configfile=paths.CA_CS_CFG_PATH,
+                msg=f'Configuration file {paths.CA_CS_CFG_PATH} is missing'
+            )
             return
 
         pki_version = pki.util.Version(pki.specification_version())

--- a/tests/test_dogtag_ca.py
+++ b/tests/test_dogtag_ca.py
@@ -50,9 +50,10 @@ class TestCACerts(BaseTest):
     @pytest.mark.skipif(
         pki_version >= pki.util.Version("11.5.0"),
         reason='Does not apply to PKI 11.5.0+')
+    @patch('os.path.exists')
     @patch('ipahealthcheck.dogtag.ca.get_directive')
     @patch('ipaserver.install.certs.CertDB')
-    def test_ca_certs_ok(self, mock_certdb, mock_directive):
+    def test_ca_certs_ok(self, mock_certdb, mock_directive, mock_exists):
         """Test what should be the standard case"""
         trust = {
             'ocspSigningCert cert-pki-ca': 'u,u,u',
@@ -62,6 +63,7 @@ class TestCACerts(BaseTest):
             'caSigningCert cert-pki-ca': 'CT,C,C',
             'transportCert cert-pki-kra': 'u,u,u',
         }
+        mock_exists.return_value = True
         mock_certdb.return_value = mock_CertDB(trust)
         mock_directive.side_effect = [name for name, nsstrust in trust.items()]
 
@@ -81,9 +83,11 @@ class TestCACerts(BaseTest):
     @pytest.mark.skipif(
         pki_version >= pki.util.Version("11.5.0"),
         reason='Does not apply to PKI 11.5.0+')
+    @patch('os.path.exists')
     @patch('ipahealthcheck.dogtag.ca.get_directive')
     @patch('ipaserver.install.certs.CertDB')
-    def test_cert_missing_from_file(self, mock_certdb, mock_directive):
+    def test_cert_missing_from_file(self, mock_certdb, mock_directive,
+                                    mock_exists):
         """Test a missing certificate.
 
            Note that if it is missing from the database then this check
@@ -103,6 +107,7 @@ class TestCACerts(BaseTest):
         location = nicknames.index('auditSigningCert cert-pki-ca')
         nicknames[location] = 'NOT auditSigningCert cert-pki-ca'
 
+        mock_exists.return_value = True
         mock_certdb.return_value = mock_CertDB(trust)
         mock_directive.side_effect = nicknames
 


### PR DESCRIPTION
This should never happen but if that file disappears things have gone really, really badly. Throw a CRITICAL error.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/327