### PR TITLE
Fix some file mode format issues

### DIFF
--- a/src/ipahealthcheck/core/files.py
+++ b/src/ipahealthcheck/core/files.py
@@ -31,7 +31,17 @@ class FileCheck:
 
     @duration
     def check(self):
-        for (path, owner, group, mode) in self.files:
+        # first validate that the list of files to check is in the correct
+        # format
+        process_files = []
+        for file in self.files:
+            if len(file) == 4:
+                process_files.append(file)
+            else:
+                yield Result(self, constants.ERROR, key=file,
+                             msg='Code format is incorrect for file')
+
+        for (path, owner, group, mode) in process_files:
             if not isinstance(owner, tuple):
                 owner = tuple((owner,))
             if not isinstance(group, tuple):

--- a/src/ipahealthcheck/ipa/files.py
+++ b/src/ipahealthcheck/ipa/files.py
@@ -121,7 +121,7 @@ class IPAFileCheck(IPAPlugin, FileCheck):
                 self.files.append((filename, 'root', 'root', '0600'))
 
         self.files.append((paths.IPA_CUSTODIA_AUDIT_LOG,
-                          'root', 'root', '0644', '0640'))
+                          'root', 'root', ('0644', '0640')))
 
         self.files.append((paths.KADMIND_LOG, 'root', 'root',
                           ('0600', '0640')))
@@ -134,12 +134,12 @@ class IPAFileCheck(IPAPlugin, FileCheck):
                            constants.DS_USER, constants.DS_GROUP, '0600'))
 
         self.files.append((paths.VAR_LOG_HTTPD_ERROR, 'root', 'root',
-                           '0644', '0640'))
+                           ('0644', '0640')))
 
         for globpath in glob.glob("%s/debug*.log" % paths.TOMCAT_CA_DIR):
             self.files.append(
                 (globpath, constants.PKI_USER, constants.PKI_GROUP,
-                 "0644", "0640")
+                 ("0644", "0640"))
             )
 
         for globpath in glob.glob(

--- a/tests/util.py
+++ b/tests/util.py
@@ -141,6 +141,7 @@ m_api.env.container_host = DN(('cn', 'computers'), ('cn', 'accounts'))
 m_api.env.container_sysaccounts = DN(('cn', 'sysaccounts'), ('cn', 'etc'))
 m_api.env.container_service = DN(('cn', 'services'), ('cn', 'accounts'))
 m_api.env.container_masters = DN(('cn', 'masters'))
+m_api.env.container_dns = DN(('cn', 'dns'))
 m_api.Backend = Mock()
 m_api.Command = Mock()
 m_api.Command.ping.return_value = {


### PR DESCRIPTION
When specifying multiple possible modes for a file the values must be a tuple. There were two occurances where they were listed separately.

Add in a pre-check on the formatting to raise an error for badly formatted files. This may be annoying for users if one sneaks in again but the CI should catch it.

Related: https://github.com/freeipa/freeipa-healthcheck/issues/325