### PR TITLE
Allow WARNING in the files test

### DIFF
--- a/tests/test_core_files.py
+++ b/tests/test_core_files.py
@@ -302,4 +302,4 @@ def test_ipa_files_format(mock_pkinit):
     results = capture_results(f)
 
     for result in results.results:
-        assert result.result == constants.SUCCESS
+        assert result.result in (constants.SUCCESS, constants.WARNING)


### PR DESCRIPTION
We are only validating the format and don't need to actually enforce the results in CI. The validation raises ERROR.

Related: https://github.com/freeipa/freeipa-healthcheck/issues/325