### PR TITLE
Check that IPA configuration has MS-PAC generation enabled

### DIFF
--- a/src/ipahealthcheck/ipa/trust.py
+++ b/src/ipahealthcheck/ipa/trust.py
@@ -684,3 +684,23 @@ class IPATrustPackageCheck(IPAPlugin):
                          key='adtrustpackage',
                          msg='trust-ad sub-package is not installed. '
                          'Administration will be limited.')
+
+
+@registry
+class IPAauthzdatapacCheck(IPAPlugin):
+    """
+    Verify that the MS-PAC generation is not disabled
+    """
+    @duration
+    def check(self):
+        ipaconfig = api.Command.config_show(raw=True)
+        krbauthzdata = ipaconfig['result'].get('ipakrbauthzdata', tuple())
+        authzdata = 'MS-PAC'
+        if authzdata not in krbauthzdata:
+            yield Result(self, constants.ERROR,
+                         key=authzdata,
+                         error='access to IPA API will not work',
+                         msg='MS-PAC generation is not enabled '
+                         'in IPA configuration {key}: {error}')
+        else:
+            yield Result(self, constants.SUCCESS, key='MS-PAC')


### PR DESCRIPTION
FreeIPA uses S4U extensions to operate on behalf of the user requesting IPA API access. S4U2Proxy extension requires presence of MS-PAC record in the Kerberos evidence ticket presented by the proxy service. This is mandatory since ~2023 to address Bronze bit CVE.

Check that 'ipa config-show' output includes 'MS-PAC' in the list of values for ipakrbauthzdata attribute.