### PR TITLE
Catch exceptions raised when making a replication agmt

### DIFF
--- a/src/ipahealthcheck/ipa/dna.py
+++ b/src/ipahealthcheck/ipa/dna.py
@@ -29,7 +29,14 @@ class IPADNARangeCheck(IPAPlugin):
 
     @duration
     def check(self):
-        agmt = replication.ReplicationManager(api.env.realm, api.env.host)
+        try:
+            agmt = replication.ReplicationManager(api.env.realm, api.env.host)
+        except Exception as e:
+            yield Result(self, constants.ERROR,
+                         key='agreement_creation_error_dna',
+                         error=str(e),
+                         msg='Connection to replica failed {error}')
+            logging.debug('Establishing agreement failed %s', e)
 
         (range_start, range_max) = agmt.get_DNA_range(api.env.host)
         (next_start, next_max) = agmt.get_DNA_next_range(api.env.host)


### PR DESCRIPTION
Calling the constructor replication.ReplicationManager will establish a connection to the replica. Catch any exceptions that might result because of this: server down, invalid credentails, etc.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/338