### PR TITLE
IPAOpenSSLChainValidation: ignore default trust store

### DIFF
--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -1074,6 +1074,7 @@ class IPAOpenSSLChainValidation(IPAPlugin):
                 '-verbose',
                 '-show_chain',
                 '-CAfile', paths.IPA_CA_CRT,
+                '-no-CAfile', '-no-CApath', '-no-CAstore',
                 file]
 
         return ipautil.run(args, raiseonerr=False)


### PR DESCRIPTION
The check IPAOpenSSLChainValidation is ensuring that the whole certification chain is present in IPA for httpd and RA certificates.
It internally calls openssl verify -CAfile /etc/ipa/ca.crt.

With the latest version of ca-certificates package, openssl verify also uses the default trust store. Since the test wants to check the chain presence in /etc/ipa/ca.crt, add the -no-CAfile -no-CApath and -no-CAstore options to ensure that only /etc/ipa/ca.crt is used as trusted source.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/340