### PR TITLE
Compatibility fix for PyCA cryptography 42.0.0

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fedora-release: [37, 38]
+        fedora-release: [40, 41]
 
     steps:
     - uses: actions/checkout@v4

--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -428,7 +428,7 @@ class IPACertfileExpirationCheck(IPAPlugin):
 
             now = datetime.now(tz=timezone.utc)
             # Older versions of IPA provide naive timestamps
-            notafter = cert.not_valid_after.replace(tzinfo=timezone.utc)
+            notafter = cert.not_valid_after_utc
 
             if now > notafter:
                 yield Result(self, constants.ERROR,
@@ -1447,7 +1447,7 @@ class IPACAChainExpirationCheck(IPAPlugin):
         for cert in ca_certs:
             subject = DN(cert.subject)
             subject = str(subject).replace('\\;', '\\3b')
-            dt = cert.not_valid_after.replace(tzinfo=timezone.utc)
+            dt = cert.not_valid_after_utc
             if dt < now:
                 logger.debug("%s is expired", subject)
                 yield Result(self, constants.CRITICAL,

--- a/tests/test_ipa_certfile_expiration.py
+++ b/tests/test_ipa_certfile_expiration.py
@@ -23,7 +23,7 @@ class IPACertificate:
         self.subject = 'CN=RA AGENT'
         self.issuer = 'CN=ISSUER'
         self.serial_number = serial_number
-        self.not_valid_after = not_valid_after
+        self.not_valid_after_utc = not_valid_after
 
 
 class TestIPACertificateFile(BaseTest):

--- a/tests/test_ipa_expiration.py
+++ b/tests/test_ipa_expiration.py
@@ -100,7 +100,7 @@ class FakeIPACertificate:
         return self.subj
 
     @property
-    def not_valid_after(self):
+    def not_valid_after_utc(self):
         return self.not_after
 
 


### PR DESCRIPTION
Cryptography 42.0.0 introduced two new abstract properties `not_valid_before_utc` and `not_valid_after_utc`, which are non-naive UTC variants of the `not_valid_before` and `not_valid_after` properties.

The old properties are deprecated. The change also modifies tests to handle the new `_utc` variants.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/345