### PR TITLE
Replace fips-mode-setup

### DIFF
--- a/src/ipahealthcheck/meta/core.py
+++ b/src/ipahealthcheck/meta/core.py
@@ -14,9 +14,6 @@ from ipapython import ipautil
 from ipapython.version import VERSION, API_VERSION
 from ipaplatform.paths import paths
 
-if 'PROC_FIPS_ENABLED' not in dir(paths):
-    paths.PROC_FIPS_ENABLED = '/proc/sys/crypto/fips_enabled'
-
 logger = logging.getLogger()
 
 

--- a/src/ipahealthcheck/meta/core.py
+++ b/src/ipahealthcheck/meta/core.py
@@ -36,10 +36,6 @@ class MetaCheck(Plugin):
                 proc_fips_enable_path = Path(paths.PROC_FIPS_ENABLED)
                 result_text = proc_fips_enable_path.read_text()
                 result = int(result_text)
-            except TimeoutError:
-                logger.debug('Reading %s timed out' % paths.PROC_FIPS_ENABLED)
-                fips = "check timed out"
-                rval = constants.ERROR
             except Exception as e:
                 logger.debug('Reading %s failed: %s' %
                              (paths.PROC_FIPS_ENABLED, e))

--- a/src/ipahealthcheck/meta/core.py
+++ b/src/ipahealthcheck/meta/core.py
@@ -28,8 +28,9 @@ class MetaCheck(Plugin):
         rval = constants.SUCCESS
         if not os.path.exists(paths.PROC_FIPS_ENABLED):
             fips = "missing {}".format(paths.PROC_FIPS_ENABLED)
-            logger.debug("Can't find %s, skipping" %
-                         paths.PROC_FIPS_ENABLED)
+            logger.warning("Can't find %s, skipping" %
+                           paths.PROC_FIPS_ENABLED)
+            rval = constants.WARNING
         else:
             try:
                 proc_fips_enable_path = Path(paths.PROC_FIPS_ENABLED)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -252,9 +252,11 @@ class TestMetaACME(BaseTest):
         assert result.kw.get('acme') == 'enabled'
 
     @patch('os.path.exists')
+    @patch('pathlib.Path.read_text')
     @patch('ipapython.ipautil.run')
-    def test_acme_unknown(self, mock_run, mock_exists):
+    def test_acme_unknown(self, mock_run, mock_result, mock_exists):
         mock_exists.return_value = True
+        mock_result.return_value = '1'
 
         mock_run.side_effect = [
             gen_result(

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -35,7 +35,7 @@ def gen_result(returncode, output='', error=''):
 
 class TestMetaFIPS(BaseTest):
     @patch('os.path.exists')
-    def test_fips_no_fips_enabled(self, mock_exists):
+    def test_fips_no_fips_available(self, mock_exists):
         mock_exists.return_value = False
 
         framework = object()
@@ -47,7 +47,7 @@ class TestMetaFIPS(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.result == constants.SUCCESS
+        assert result.result == constants.WARNING
         assert result.source == 'ipahealthcheck.meta.core'
         assert result.check == 'MetaCheck'
         assert result.kw.get('fips') == 'missing %s' % paths.PROC_FIPS_ENABLED
@@ -195,7 +195,7 @@ class TestMetaACME(BaseTest):
         assert len(self.results) == 1
 
         result = self.results.results[0]
-        assert result.result == constants.SUCCESS
+        assert result.result == constants.WARNING
         assert result.source == 'ipahealthcheck.meta.core'
         assert result.check == 'MetaCheck'
         assert result.kw.get('acme') == \

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -12,9 +12,6 @@ from ipahealthcheck.meta.plugin import registry
 from ipahealthcheck.meta.core import MetaCheck
 from ipaplatform.paths import paths
 
-if 'PROC_FIPS_ENABLED' not in dir(paths):
-    paths.PROC_FIPS_ENABLED = '/proc/sys/crypto/fips_enabled'
-
 
 def gen_result(returncode, output='', error=''):
     """


### PR DESCRIPTION
RHEL10 doesn't support fips-mode-setup, therefore this call has been replaced with simple reading of a proc file. The tests have been edited accordingly, inconsistent has been removed and instead replaced by a test supplying an arbitrary value, that should never occur.

Fixes: #350