### PR TITLE
Don't rely on order in trust agent/controller role check

### DIFF
--- a/src/ipahealthcheck/ipa/plugin.py
+++ b/src/ipahealthcheck/ipa/plugin.py
@@ -35,6 +35,13 @@ class IPARegistry(Registry):
         self.trust_controller = False
         self.ca_configured = False
 
+    def has_role(self, roles):
+        for role in roles:
+            if role.get('server_server') == api.env.host:
+                if role.get('status') == 'enabled':
+                    return True
+        return False
+
     def initialize(self, framework, config, options=None):
         super().initialize(framework, config)
         # deferred import for mock
@@ -81,12 +88,8 @@ class IPARegistry(Registry):
                 component_services=['ADTRUST']
             ),
         )
-        role = roles[0].status(api)[0]
-        if role.get('status') == 'enabled':
-            self.trust_agent = True
-        role = roles[1].status(api)[0]
-        if role.get('status') == 'enabled':
-            self.trust_controller = True
+        self.trust_agent = self.has_role(roles[0].status(api))
+        self.trust_controller = self.has_role(roles[1].status(api))
 
 
 registry = IPARegistry()


### PR DESCRIPTION
The code expected that the local server would always be the first one returned. Instead loop through the returned list to find the current server and set the state based on that.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/356