### PR TITLE
Add /etc/pki/tls/certs/ directory to file checker

### DIFF
--- a/src/ipahealthcheck/ipa/files.py
+++ b/src/ipahealthcheck/ipa/files.py
@@ -101,6 +101,8 @@ class IPAFileCheck(IPAPlugin, FileCheck):
                           ('root', 'systemd-resolve'), '0644'))
         self.files.append((paths.HOSTS, 'root', 'root', '0644'))
 
+        self.files.append((paths.OPENSSL_CERTS_DIR, 'root', 'root', '0755'))
+
         # IPA log files that may vary by installation. Only verify
         # those that exist
         for filename in (


### PR DESCRIPTION
In order to load the CA bundle /etc/pki/tls/certs needs to be world-readable. That or the group needs to change if someone wants to get really restrictive but that's likely to cause further unforseen issues elsewhere. This directory contains only public information.

Restrictive permissions will cause pki-tomcatd to fail to start.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/358

## Summary by Sourcery

Add the OpenSSL certs directory to the permission checks to ensure /etc/pki/tls/certs is accessible, fixing related startup errors

Bug Fixes:
- Prevent pki-tomcatd startup failures due to restrictive permissions on the OpenSSL certs directory

Enhancements:
- Add /etc/pki/tls/certs to the file permission checker with 0755 permissions