### PR TITLE
Switch to F41 and F42 for testing

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fedora-release: [40, 41]
+        fedora-release: [41, 42]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
F40 was EOL in May, 2025.

## Summary by Sourcery

CI:
- Update Fedora release matrix to run tests on Fedora 41 and 42 in CI workflows