### PR TITLE
Report if an expiring certificate is externally signed

### DIFF
--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -304,6 +304,9 @@ class IPACertmongerExpirationCheck(IPAPlugin):
                                          'nickname'))
             notafter = int(request.prop_if.Get(certmonger.DBUS_CM_REQUEST_IF,
                                                'not-valid-after'))
+            cert = str(request.prop_if.Get(certmonger.DBUS_CM_REQUEST_IF,
+                                           'cert'))
+
             if notafter == 0:
                 yield Result(self, constants.ERROR,
                              key=id,
@@ -312,27 +315,53 @@ class IPACertmongerExpirationCheck(IPAPlugin):
                                  'has not been issued yet.')
                 continue
 
+            # if we have notafter then we should have a cert but lets not
+            # assume.
+            is_ipa_issued = None
+            if cert:
+                try:
+                    cert = x509.load_certificate_list(cert.encode('utf-8'))[0]
+                except Exception as e:
+                    logger.debug("Failed to load certificate: ", e)
+                else:
+                    is_ipa_issued = is_ipa_issued_cert(api, cert)
+
+            if is_ipa_issued is not None and not is_ipa_issued:
+                external_msg = (
+                    'This is not an IPA-issued certificate and '
+                    'will not auto-renew.')
+            else:
+                external_msg = ''
+
             nafter = datetime.fromtimestamp(notafter, timezone.utc)
             now = datetime.now(timezone.utc)
 
             if now > nafter:
+                msg = (
+                    'Request id {key} expired on {expiration_date}. '
+                    + external_msg)
                 yield Result(self, constants.ERROR,
                              key=id,
                              expiration_date=generalized_time(nafter),
-                             msg='Request id {key} expired on '
-                                 '{expiration_date}')
+                             msg=msg)
             else:
                 delta = nafter - now
                 diff = int(delta.total_seconds() / DAY)
                 if diff < int(self.config.cert_expiration_days):
+                    msg = 'Request id {key} expires in {days}. '
+                    if external_msg:
+                        msg = msg + external_msg
+                    else:
+                        msg = msg + (
+                             'certmonger should renew this '
+                             'automatically. Watch the status with '
+                             'getcert list -i {key}.'
+                        )
                     yield Result(self, constants.WARNING,
                                  key=id,
                                  expiration_date=generalized_time(nafter),
                                  days=diff,
-                                 msg='Request id {key} expires in {days} '
-                                     'days. certmonger should renew this '
-                                     'automatically. Watch the status with '
-                                     'getcert list -i {key}.')
+                                 msg=msg)
                 else:
                     yield Result(self, constants.SUCCESS,
                                  key=id)

--- a/tests/mock_certmonger.py
+++ b/tests/mock_certmonger.py
@@ -23,6 +23,7 @@ pristine_cm_requests = [
         'cert-storage': 'FILE',
         'cert-presave-command': template % 'renew_ra_cert_pre',
         'cert-postsave-command': template % 'renew_ra_cert',
+        'cert': '----- BEGIN -----',
         'not-valid-after': (
             int(
                 datetime(1970, 1, 1, 0, 17, 4, tzinfo=timezone.utc).timestamp()
@@ -37,6 +38,7 @@ pristine_cm_requests = [
         'template_profile': 'caIPAserviceCert',
         'cert-storage': 'FILE',
         'cert-postsave-command': template % 'restart_httpd',
+        'cert': '----- BEGIN -----',
         'not-valid-after': (
             int(
                 (

--- a/tests/test_ipa_tracking.py
+++ b/tests/test_ipa_tracking.py
@@ -59,7 +59,8 @@ class TestTracking(BaseTest):
             "cert-presave-command=" \
             "/usr/libexec/ipa/certmonger/renew_ra_cert_pre, " \
             "cert-postsave-command=" \
-            "/usr/libexec/ipa/certmonger/renew_ra_cert"
+            "/usr/libexec/ipa/certmonger/renew_ra_cert, " \
+            "cert=----- BEGIN -----"
 
     def test_unknown_cert_tracking(self):
         # Add a custom, unknown request


### PR DESCRIPTION
This is intended for externally-signed IPA CA certificates. It should not duplicate user-provided certificats because this check, IPACertmongerExpirationCheck, is based on certmonger tracking and we don't track, by default, user-provided certs.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/104