### PR TITLE
Add a message to Trust checks if not a trust agent/controller

### DIFF
--- a/src/ipahealthcheck/ipa/trust.py
+++ b/src/ipahealthcheck/ipa/trust.py
@@ -67,6 +67,8 @@ class IPATrustAgentCheck(IPAPlugin):
     def check(self):
         if not self.registry.trust_agent:
             logger.debug('Not a trust agent, skipping')
+            yield Result(self, constants.SUCCESS,
+                         msg="Skipped. Not a trust agent")
             return
 
         try:
@@ -123,6 +125,8 @@ class IPATrustDomainsCheck(IPAPlugin):
     def check(self):
         if not self.registry.trust_agent:
             logger.debug('Not a trust agent, skipping')
+            yield Result(self, constants.SUCCESS,
+                         msg="Skipped. Not a trust agent")
             return
 
         result = ipautil.run([paths.SSSCTL, "domain-list"], raiseonerr=False,
@@ -272,6 +276,8 @@ class IPATrustCatalogCheck(IPAPlugin):
     def check(self):
         if not self.registry.trust_agent:
             logger.debug('Not a trust agent, skipping')
+            yield Result(self, constants.SUCCESS,
+                         msg="Skipped. Not a trust agent")
             return
 
         try:
@@ -360,6 +366,8 @@ class IPAsidgenpluginCheck(IPAPlugin):
     def check(self):
         if not self.registry.trust_agent:
             logger.debug('Not a trust agent, skipping')
+            yield Result(self, constants.SUCCESS,
+                         msg="Skipped. Not a trust agent")
             return
 
         for plugin in ['IPA SIDGEN', 'ipa-sidgen-task']:
@@ -403,6 +411,8 @@ class IPATrustAgentMemberCheck(IPAPlugin):
     def check(self):
         if not self.registry.trust_agent:
             logger.debug('Not a trust agent, skipping')
+            yield Result(self, constants.SUCCESS,
+                         msg="Skipped. Not a trust agent")
             return
 
         agent_dn = DN(('fqdn', api.env.host), api.env.container_host,
@@ -442,6 +452,8 @@ class IPATrustControllerPrincipalCheck(IPAPlugin):
     def check(self):
         if not self.registry.trust_controller:
             logger.debug('Not a trust controller, skipping')
+            yield Result(self, constants.SUCCESS,
+                         msg="Skipped. Not a trust controller")
             return
 
         agent_dn = DN(('krbprincipalname',
@@ -483,6 +495,8 @@ class IPATrustControllerServiceCheck(IPAPlugin):
     def check(self):
         if not self.registry.trust_controller:
             logger.debug('Not a trust controller, skipping')
+            yield Result(self, constants.SUCCESS,
+                         msg="Skipped. Not a trust controller")
             return
 
         service_dn = DN(('cn', 'ADTRUST'), ('cn', api.env.host),
@@ -526,6 +540,8 @@ class IPATrustControllerConfCheck(IPAPlugin):
     def check(self):
         if not self.registry.trust_controller:
             logger.debug('Not a trust controller, skipping')
+            yield Result(self, constants.SUCCESS,
+                         msg="Skipped. Not a trust controller")
             return
 
         ldapi_socket = "ipasam:ldapi://%%2fvar%%2frun%%2fslapd-%s.socket" % \
@@ -586,6 +602,8 @@ class IPATrustControllerGroupSIDCheck(IPAPlugin):
     def check(self):
         if not self.registry.trust_controller:
             logger.debug('Not a trust controller, skipping')
+            yield Result(self, constants.SUCCESS,
+                         msg="Skipped. Not a trust controller")
             return
 
         admins_dn = DN(('cn', 'admins'),
@@ -624,6 +642,8 @@ class IPATrustControllerAdminSIDCheck(IPAPlugin):
     def check(self):
         if not self.registry.trust_controller:
             logger.debug('Not a trust controller, skipping')
+            yield Result(self, constants.SUCCESS,
+                         msg="Skipped. Not a trust controller")
             return
 
         admin_dn = DN(('uid', 'admin'),
@@ -667,9 +687,13 @@ class IPATrustPackageCheck(IPAPlugin):
     def check(self):
         if self.registry.trust_controller:
             logger.debug('Trust controller, skipping')
+            yield Result(self, constants.SUCCESS,
+                         msg="Skipped. Not a trust controller")
             return
         if not self.registry.trust_agent:
             logger.debug('Not a trust agent, skipping')
+            yield Result(self, constants.SUCCESS,
+                         msg="Skipped. Not a trust agent")
             return
 
         # The trust-ad package provides this import

--- a/tests/test_ipa_trust.py
+++ b/tests/test_ipa_trust.py
@@ -245,8 +245,9 @@ class TestTrustAgent(BaseTest):
 
         self.results = capture_results(f)
 
-        # Zero because the call was skipped altogether
-        assert len(self.results) == 0
+        assert len(self.results) == 1
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
 
     @patch('SSSDConfig.SSSDConfig')
     def test_trust_agent_ok(self, mock_sssd):
@@ -316,8 +317,9 @@ class TestTrustDomains(BaseTest):
 
         self.results = capture_results(f)
 
-        # Zero because the call was skipped altogether
-        assert len(self.results) == 0
+        assert len(self.results) == 1
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
 
     @patch('ipapython.ipautil.run')
     def test_trust_domain_list_fail(self, mock_run):
@@ -519,8 +521,9 @@ class TestTrustCatalog(BaseTest):
 
         self.results = capture_results(f)
 
-        # Zero because the call was skipped altogether
-        assert len(self.results) == 0
+        assert len(self.results) == 1
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
 
     @patch('pysss_nss_idmap.getnamebysid')
     @patch('ipapython.ipautil.run')
@@ -779,8 +782,9 @@ class Testsidgen(BaseTest):
 
         self.results = capture_results(f)
 
-        # Zero because the call was skipped altogether
-        assert len(self.results) == 0
+        assert len(self.results) == 1
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
 
     def test_sidgen_ok(self):
         attrs = {
@@ -859,8 +863,9 @@ class TestTrustAgentMember(BaseTest):
 
         self.results = capture_results(f)
 
-        # Zero because the call was skipped altogether
-        assert len(self.results) == 0
+        assert len(self.results) == 1
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
 
     def test_member_ok(self):
         agent_dn = DN(('fqdn', m_api.env.host), m_api.env.container_host,
@@ -934,8 +939,9 @@ class TestControllerPrincipal(BaseTest):
 
         self.results = capture_results(f)
 
-        # Zero because the call was skipped altogether
-        assert len(self.results) == 0
+        assert len(self.results) == 1
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
 
     def test_principal_ok(self):
         agent_dn = DN(('krbprincipalname',
@@ -1011,8 +1017,9 @@ class TestControllerService(BaseTest):
 
         self.results = capture_results(f)
 
-        # Zero because the call was skipped altogether
-        assert len(self.results) == 0
+        assert len(self.results) == 1
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
 
     def test_service_enabled(self):
         service_dn = DN(('cn', 'ADTRUST'))
@@ -1081,8 +1088,9 @@ class TestControllerGroupSID(BaseTest):
 
         self.results = capture_results(f)
 
-        # Zero because the call was skipped altogether
-        assert len(self.results) == 0
+        assert len(self.results) == 1
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
 
     def test_principal_ok(self):
         admins_dn = DN(('cn', 'admins'))
@@ -1155,8 +1163,9 @@ class TestControllerAdminSID(BaseTest):
 
         self.results = capture_results(f)
 
-        # Zero because the call was skipped altogether
-        assert len(self.results) == 0
+        assert len(self.results) == 1
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
 
     def test_principal_ok(self):
         admin_dn = DN(('uid', 'admin'))
@@ -1229,8 +1238,9 @@ class TestControllerConf(BaseTest):
 
         self.results = capture_results(f)
 
-        # Zero because the call was skipped altogether
-        assert len(self.results) == 0
+        assert len(self.results) == 1
+        result = self.results.results[0]
+        assert result.result == constants.SUCCESS
 
     @patch('ipapython.ipautil.run')
     def test_ldapi_ok(self, mock_run):


### PR DESCRIPTION
Previously it would return an empty SUCCESS message because if the server is not an agent and/or controller role then there is nothing to do. So return a message that indicates this.

Note: this is a change in behavior. The test used to be skipped altogether so returned no result at all. Returning a result will help ensure that all tests were executed.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/85

## Summary by Sourcery

Return a success result with an explanatory message for all trust checks when the server is not a trust agent or controller, ensuring skipped tests still produce a result.

Enhancements:
- Have each trust agent and controller plugin yield a SUCCESS result with a “Skipped. Not a trust agent/controller” message instead of silently skipping.

Tests:
- Update trust-related tests to expect one SUCCESS result with the skip message instead of zero results for skipped scenarios.