### PR TITLE
add ipa-certupdate hint for missing LWCA tracking request

### DIFF
--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -596,7 +596,10 @@ class IPACertTracking(IPAPlugin):
                              key=flatten,
                              msg='Expected certmonger tracking is missing for '
                                  '{key}. Automated renewal will not happen '
-                                 'for this certificate')
+                                 'for this certificate. Run ipa-certupdate(1) '
+                                 'to add tracking requests for lightweight '
+                                 'CAs.'
+                             )
                 continue
 
         # Report any unknown certmonger requests as warnings


### PR DESCRIPTION
Missing LWCA tracking requests is an expected scenario.  Admins need to run `ipa-certupdate` to set up the tracking requests.  Include this hint in the error message.

Drive-by change, no ticket.