### PR TITLE
Migrate from pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import find_packages, setup
 setup(
     name='ipahealthcheck',
     version='0.18',
-    namespace_packages=['ipahealthcheck', 'ipaclustercheck'],
     package_dir={'': 'src'},
     # packages=find_packages(where='src'),
     packages=[
@@ -16,6 +15,10 @@ setup(
         'ipahealthcheck.system',
         'ipaclustercheck.core',
         'ipaclustercheck.ipa',
+    ],
+    # Add importlib-metadata for Python < 3.8 compatibility
+    install_requires=[
+        'importlib-metadata>=1.0; python_version<"3.8"',
     ],
     entry_points={
         # creates bin/ipahealthcheck
@@ -83,6 +86,11 @@ setup(
     },
     classifiers=[
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
-    python_requires='!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
+    python_requires='>=3.6',
 )

--- a/src/ipaclustercheck/__init__.py
+++ b/src/ipaclustercheck/__init__.py
@@ -1,5 +1,3 @@
 #
 # Copyright (C) 2019 FreeIPA Contributors see COPYING for license
 #
-
-__import__('pkg_resources').declare_namespace(__name__)

--- a/src/ipahealthcheck/__init__.py
+++ b/src/ipahealthcheck/__init__.py
@@ -1,5 +1,3 @@
 #
 # Copyright (C) 2019 FreeIPA Contributors see COPYING for license
 #
-
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
The usage of pkg_resources (subpackage of setuptools distribution) is discouraged.

https://setuptools.pypa.io/en/latest/pkg_resources.html:

  Use of pkg_resources is discouraged in favor of importlib.resources,
  importlib.metadata, and their backports (importlib_resources,
  importlib_metadata). Please consider using those libraries instead
  of pkg_resources.

freeipa-healthcheck uses several points of pkg_resources:

 * pkg_resources.iter_entry_points to access entry points. migration: https://importlib-metadata.readthedocs.io/en/latest/migration.html#pkg-resources-iter-entry-points
 * pkg_resources.get_distribution to access a distribution. migration: https://importlib-metadata.readthedocs.io/en/latest/migration.html#pkg-resources-get-distribution
 * __import__('pkg_resources').declare_namespace https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#creating-a-namespace-package

Compatibility note: importlib.metadata is in stdlib since Python 3.8: https://docs.python.org/3/library/importlib.metadata.html

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/273