### PR TITLE
IPAFileCheck: also allow 640 for kra debug log

### DIFF
--- a/src/ipahealthcheck/ipa/files.py
+++ b/src/ipahealthcheck/ipa/files.py
@@ -159,7 +159,8 @@ class IPAFileCheck(IPAPlugin, FileCheck):
 
         for globpath in glob.glob("%s/debug*.log" % paths.TOMCAT_KRA_DIR):
             self.files.append(
-                (globpath, constants.PKI_USER, constants.PKI_GROUP, "0644")
+                (globpath, constants.PKI_USER, constants.PKI_GROUP,
+                 ("0644", "0640"))
             )
 
         for globpath in glob.glob(


### PR DESCRIPTION
The check ipahealthcheck.ipa.files.IPAFileCheck reports an error with PKI 11.9.1 because this update changed the permissions on /var/log/pki/pki-tomcat/kar/debug.$DATE.log to 0640 instead of 0644.

Allow both values as we already do for CA debug log.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/374

## Summary by Sourcery

Bug Fixes:
- Treat KRA tomcat debug log files with either 0644 or 0640 permissions as valid in IPA file health checks.