### PR TITLE
Make --list-sources respect --output-type and --output-file

### DIFF
--- a/src/ipahealthcheck/core/core.py
+++ b/src/ipahealthcheck/core/core.py
@@ -198,15 +198,16 @@ def run_plugins(plugins, available, source, check,
 
 
 def list_sources(plugins):
-    """Print list of all sources and checks"""
-    source = None
+    """Return a list of sources and their checks"""
+    sources = {}
     for plugin in plugins:
-        if source != plugin.__class__.__module__:
-            print(plugin.__class__.__module__)
-            source = plugin.__class__.__module__
-        print("  ", plugin.__class__.__name__)
-
-    return 0
+        module = plugin.__class__.__module__
+        name = plugin.__class__.__name__
+        sources.setdefault(module, []).append(name)
+    return [
+        {"source": source, "checks": checks}
+        for source, checks in sources.items()
+    ]
 
 
 def add_default_options(parser, output_registry, default_output):
@@ -251,6 +252,11 @@ def parse_options(parser):
     # Validation
     if options.check and not options.source:
         raise ValueError("--source is required when --check is used")
+
+    if options.list_sources and options.output_type == 'prometheus':
+        raise ValueError(
+            "--output-type=prometheus is not supported with --list-sources"
+        )
 
     return options
 
@@ -426,7 +432,8 @@ class RunChecks:
             return 1
 
         if options.list_sources:
-            return list_sources(plugins)
+            output.render_source_list(list_sources(plugins))
+            return 0
 
         if 'infile' in options and options.infile:
             try:

--- a/src/ipahealthcheck/core/output.py
+++ b/src/ipahealthcheck/core/output.py
@@ -120,6 +120,22 @@ class Output:
         """
         raise NotImplementedError
 
+    def render_source_list(self, data):
+        """Process the source list into output"""
+        output = self.generate_source_list(data)
+        self.write_file(output)
+
+    def generate_source_list(self, data):
+        """Convert the source list to the desired format, ready for writing
+
+           Output plugins should override this method to provide
+           source list formatting. The return value should be in
+           ready-to-write format.
+
+           Returns a string.
+        """
+        raise NotImplementedError
+
 
 @output_registry
 class JSON(Output):
@@ -135,6 +151,13 @@ class JSON(Output):
         self.indent = options.indent
 
     def generate(self, data):
+        output = json.dumps(data, indent=self.indent)
+        if self.filename is None:
+            output += '\n'
+
+        return output
+
+    def generate_source_list(self, data):
         output = json.dumps(data, indent=self.indent)
         if self.filename is None:
             output += '\n'
@@ -166,6 +189,17 @@ class Human(Output):
             elif 'exception' in kw:
                 outline += ': %s' % kw.get('exception')
             output += outline + '\n'
+
+        return output
+
+    def generate_source_list(self, data):
+        output = ''
+        for item in data:
+            source = item.get('source')
+            checks = ['  %s' % check for check in item.get('checks', [])]
+            output += source + '\n'
+            if checks:
+                output += "\n".join(checks) + '\n'
 
         return output
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -137,3 +137,39 @@ def test_incorrect_delimiter_cfg_file(mock_parse, mock_run, mock_service,
 
     finally:
         os.remove(config_path)
+
+
+def test_list_sources_prometheus_incompatible():
+    """
+    Test that --list-sources with --output-type=prometheus raises an error
+
+    The Prometheus output format doesn't support source listing.
+    """
+    from ipahealthcheck.core.core import parse_options
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--list-sources', dest='list_sources',
+                        action='store_true', default=False)
+    parser.add_argument('--output-type', dest='output_type',
+                        choices=['json', 'human', 'prometheus'],
+                        default='json')
+    parser.add_argument('--source', dest='source', default=None)
+    parser.add_argument('--check', dest='check', default=None)
+
+    # Mock sys.argv to simulate --list-sources --output-type=prometheus
+    import sys
+    original_argv = sys.argv
+    try:
+        sys.argv = ['test', '--list-sources', '--output-type=prometheus']
+
+        # This should raise a ValueError
+        try:
+            parse_options(parser)
+            assert False, "Expected ValueError was not raised"
+        except ValueError as e:
+            assert (
+                "--output-type=prometheus is not supported "
+                "with --list-sources" in str(e)
+            )
+    finally:
+        sys.argv = original_argv


### PR DESCRIPTION
Refactor list_sources() to return structured data instead of printing directly to stdout. Route output through the output plugin system so that --output-type controls the format (json, human, prometheus) and --output-file controls the destination.

This allows users to get machine-readable JSON output of available sources and checks, making it easier to programmatically query what checks are available.

The human output format remains unchanged from the original plain text format. JSON produces an array of {source, checks} objects. Prometheus raises an error as source listing has no meaningful metric representation.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Route source listing through the output plugin system so it respects configured output type and destination.

New Features:
- Support structured source listing output via JSON and human output plugins, controlled by --output-type and --output-file.

Enhancements:
- Refactor list_sources() to return structured source/check data instead of printing directly to stdout.
- Disallow using --list-sources with Prometheus output and surface a clear error message from both the CLI and Prometheus output plugin.

Tests:
- Add a CLI options test asserting that --list-sources with --output-type=prometheus raises a ValueError.