### PR TITLE
Add description field to healthcheck results

### DIFF
--- a/src/ipahealthcheck/core/plugin.py
+++ b/src/ipahealthcheck/core/plugin.py
@@ -99,6 +99,7 @@ class Plugin:
 
     """
     requires = ()
+    description = None
 
     def __init__(self, registry):
         self.registry = registry
@@ -129,7 +130,7 @@ class Result:
         exception: used when a check raises an exception
     """
     def __init__(self, plugin, result, source=None, check=None,
-                 start=None, duration=None, when=None, **kw):
+                 start=None, duration=None, when=None, description=None, **kw):
         self.result = result
         self.kw = kw
         self.when = when or generalized_time(datetime.now(timezone.utc))
@@ -138,11 +139,13 @@ class Result:
         if None not in (check, source):
             self.check = check
             self.source = source
+            self.description = description
         else:
             if plugin is None:
                 raise TypeError('source and check or plugin must be provided')
             self.check = plugin.__class__.__name__
             self.source = plugin.__class__.__module__
+            self.description = getattr(plugin, 'description', None)
         if start is not None:
             dur = datetime.now(tz=timezone.utc) - start
             self.duration = '%6.6f' % dur.total_seconds()
@@ -184,13 +187,16 @@ class Results:
 
     def output(self):
         for result in self.results:
-            yield dict(source=result.source,
-                       check=result.check,
-                       result=getLevelName(result.result),
-                       uuid=result.uuid,
-                       when=result.when,
-                       duration=result.duration,
-                       kw=result.kw)
+            d = dict(source=result.source,
+                     check=result.check,
+                     result=getLevelName(result.result),
+                     uuid=result.uuid,
+                     when=result.when,
+                     duration=result.duration,
+                     kw=result.kw)
+            if result.description is not None:
+                d['description'] = result.description
+            yield d
 
 
 def json_to_results(data):
@@ -209,9 +215,10 @@ def json_to_results(data):
         check = line.pop('check')
         duration = line.pop('duration')
         when = line.pop('when')
+        description = line.pop('description', None)
         kw = line.pop('kw')
         result = Result(None, result, source, check, duration=duration,
-                        when=when, **kw)
+                        when=when, description=description, **kw)
         results.add(result)
 
     return results

--- a/src/ipahealthcheck/dogtag/ca.py
+++ b/src/ipahealthcheck/dogtag/ca.py
@@ -27,6 +27,10 @@ class DogtagCertsConfigCheck(DogtagPlugin):
     """
     Compare the cert blob in the NSS database to that stored in CS.cfg
     """
+    description = (
+        "Compares the CA and KRA certificate values with those in CS.cfg"
+    )
+
     @duration
     def check(self):
         if not self.ca.is_configured():
@@ -117,6 +121,7 @@ class DogtagCertsConnectivityCheck(DogtagPlugin):
     know this certificate should exist. Use its serial number to do
     the lookup.
     """
+    description = "Verifies basic CA connectivity by running cert-show"
     requires = ('dirsrv',)
 
     @duration

--- a/src/ipahealthcheck/ipa/certs.py
+++ b/src/ipahealthcheck/ipa/certs.py
@@ -292,6 +292,8 @@ class IPACertmongerExpirationCheck(IPAPlugin):
     This is to ensure something hasn't changed certmonger's view of
     the world.
     """
+    description = "Checks expiration of certmonger-tracked certificates"
+
     @duration
     def check(self):
         cm = certmonger._certmonger()
@@ -379,6 +381,10 @@ class IPACertfileExpirationCheck(IPAPlugin):
     This is to ensure a certificate wasn't replaced without
     certmonger being notified.
     """
+    description = (
+        "Checks certificate expiration from PEM files or NSS databases"
+    )
+
     @duration
     def check(self):
         cm = certmonger._certmonger()
@@ -580,6 +586,10 @@ class IPACertTracking(IPAPlugin):
        6. Report on all tracked certs that IPA didn't setup itself as
           potential issues.
     """
+    description = (
+        "Compares certmonger tracking to expected certificate "
+        "configuration"
+    )
 
     requires = ('dirsrv',)
 
@@ -750,6 +760,10 @@ class IPACertDNSSAN(IPAPlugin):
 @registry
 class IPACertNSSTrust(IPAPlugin):
     """Compare the NSS trust for the CA certs to a known good value"""
+    description = (
+        "Verifies NSS database certificate trust flags against expected "
+        "values"
+    )
 
     @duration
     def check(self):
@@ -837,6 +851,9 @@ class IPACertMatchCheck(IPAPlugin):
     """
     Ensure certificates match between LDAP and NSS databases
     """
+    description = (
+        "Ensures CA certificate entries in LDAP and NSS databases match"
+    )
 
     requires = ('dirsrv',)
 
@@ -945,6 +962,8 @@ class IPADogtagCertsMatchCheck(IPAPlugin):
     """
     Check if dogtag certs present in both NSS DB and LDAP match
     """
+    description = "Checks if Dogtag certificates in NSS DB and LDAP match"
+
     requires = ('dirsrv',)
 
     @duration
@@ -1078,6 +1097,7 @@ class IPADogtagCertsMatchCheck(IPAPlugin):
 @registry
 class IPANSSChainValidation(IPAPlugin):
     """Validate the certificate chain of the certs."""
+    description = "Validates the certificate chain of NSS certificates"
 
     def validate_nss(self, dbdir, dbtype, pinfile, nickname):
         """Call out to certutil to verify a certificate.
@@ -1175,6 +1195,7 @@ class IPANSSChainValidation(IPAPlugin):
 @registry
 class IPAOpenSSLChainValidation(IPAPlugin):
     """Validate the certificate chain of the certs."""
+    description = "Validates the certificate chain of OpenSSL certificates"
 
     def validate_openssl(self, file):
         """Call out to openssl to verify a certificate against global chain
@@ -1317,6 +1338,7 @@ class IPARAAgent(IPAPlugin):
 
        Compare the description and usercertificate values.
     """
+    description = "Verifies the RA agent certificate entry in LDAP"
 
     requires = ('dirsrv',)
 
@@ -1336,6 +1358,7 @@ class IPAKRAAgent(IPAPlugin):
 
        Compare the description and usercertificate values.
     """
+    description = "Verifies the KRA agent certificate entry in LDAP"
 
     requires = ('dirsrv',)
 
@@ -1361,6 +1384,7 @@ class IPACertRevocation(IPAPlugin):
        This uses the certmonger expected tracking list to know which
        one(s) to consider.
     """
+    description = "Confirms that IPA certificates are not revoked"
 
     revocation_reason = [
         "unspecified",
@@ -1495,6 +1519,7 @@ class IPACertmongerCA(IPAPlugin):
 
        Addresses symptom of https://pagure.io/freeipa/issue/7870
     """
+    description = "Checks that the certmonger CA configuration is correct"
 
     def find_ca(self, name):
         cm = certmonger._certmonger()
@@ -1530,6 +1555,7 @@ class IPACertmongerCA(IPAPlugin):
 class IPACAChainExpirationCheck(IPAPlugin):
     """Verify that the certs in the CA chain in /etc/ipa/ca.crt are valid
     """
+    description = "Checks the CA chain from /etc/ipa/ca.crt for expiration"
 
     @duration
     def check(self):

--- a/src/ipahealthcheck/ipa/config.py
+++ b/src/ipahealthcheck/ipa/config.py
@@ -21,6 +21,10 @@ class IPAkrbLastSuccessfulAuth(IPAPlugin):
     """Warn if krbLastSuccessfulAuth is enabled. It can cause
        performance issues.
     """
+    description = (
+        "Warns if krbLastSuccessfulAuth logging may cause performance "
+        "issues"
+    )
     requires = ('dirsrv',)
 
     @duration
@@ -62,6 +66,7 @@ class SSSDAllowedUids389Check(IPAPlugin):
     If UID 389 is in allowed_uids, SSSD will prevent local resolution
     which will cause issues with the IPA services.
     """
+    description = "Checks that the 389 user is not in SSSD allowed_uids"
 
     @duration
     def check(self):

--- a/src/ipahealthcheck/ipa/dna.py
+++ b/src/ipahealthcheck/ipa/dna.py
@@ -25,6 +25,7 @@ class IPADNARangeCheck(IPAPlugin):
     if a master does not have a range. It IS an error if no masters have
     a range.
     """
+    description = "Reports the configured DNA range for this master"
     requires = ('dirsrv',)
 
     @duration

--- a/src/ipahealthcheck/ipa/files.py
+++ b/src/ipahealthcheck/ipa/files.py
@@ -25,6 +25,7 @@ logger = logging.getLogger()
 
 @registry
 class IPAFileNSSDBCheck(IPAPlugin, FileCheck):
+    description = "Verifies owner and permissions of NSS database files"
 
     def collect_files(self, basedir, filelist, owner, group, perms):
         for file in filelist:
@@ -55,6 +56,8 @@ class IPAFileNSSDBCheck(IPAPlugin, FileCheck):
 
 @registry
 class IPAFileCheck(IPAPlugin, FileCheck):
+    description = "Verifies owner and permissions of IPA-managed files"
+
     def dns_container_exists(self):
         try:
             self.conn.get_entry(DN(api.env.container_dns,
@@ -187,6 +190,10 @@ class IPAFileCheck(IPAPlugin, FileCheck):
 
 @registry
 class TomcatFileCheck(IPAPlugin, FileCheck):
+    description = (
+        "Verifies owner and permissions of Tomcat configuration files"
+    )
+
     def check(self):
         if not self.ca.is_configured():
             logger.debug('CA is not configured, skipping')

--- a/src/ipahealthcheck/ipa/host.py
+++ b/src/ipahealthcheck/ipa/host.py
@@ -59,6 +59,7 @@ class CheckKeytab(IPAPlugin):
 @registry
 class IPAHostKeytab(CheckKeytab):
     """Ensure the host keytab can get a TGT"""
+    description = "Verifies the host keytab can obtain a TGT"
     requires = ('krb5kdc', 'dirsrv')
     service = 'host'
     keytab = paths.KRB5_KEYTAB

--- a/src/ipahealthcheck/ipa/roles.py
+++ b/src/ipahealthcheck/ipa/roles.py
@@ -24,6 +24,8 @@ class IPACRLManagerCheck(IPAPlugin):
     useful in the context of the ohter masters. Some external
     service is expected to aggregate this.
     """
+    description = "Determines if this master is the CRL manager"
+
     @duration
     def check(self):
         if not self.ca.is_configured():
@@ -50,6 +52,7 @@ class IPARenewalMasterCheck(IPAPlugin):
     useful in the context of the ohter masters. Some external
     service is expected to aggregate this.
     """
+    description = "Determines if this master is the CA renewal master"
     requires = ('dirsrv',)
 
     @duration

--- a/src/ipahealthcheck/ipa/topology.py
+++ b/src/ipahealthcheck/ipa/topology.py
@@ -23,6 +23,10 @@ class IPATopologyDomainCheck(IPAPlugin):
       * too many agreements
       * connection errors
     """
+    description = (
+        "Verifies the replication topology using topologysuffix-verify"
+    )
+
     def report_errors(self, suffix, result):
         if result['result']['in_order']:
             yield Result(self, constants.SUCCESS, suffix=suffix)

--- a/src/ipahealthcheck/ipa/trust.py
+++ b/src/ipahealthcheck/ipa/trust.py
@@ -63,6 +63,8 @@ class IPATrustAgentCheck(IPAPlugin):
     """
     Check the values that should be set when configures as a trust agent.
     """
+    description = "Checks the SSSD configuration for trust agent setup"
+
     @duration
     def check(self):
         if not self.registry.trust_agent:
@@ -121,6 +123,11 @@ class IPATrustDomainsCheck(IPAPlugin):
     """
     Check the trust domains
     """
+    description = (
+        "Ensures IPA domain is in sssctl domain-list and trust domains "
+        "match"
+    )
+
     @duration
     def check(self):
         if not self.registry.trust_agent:
@@ -272,6 +279,11 @@ class IPATrustCatalogCheck(IPAPlugin):
     check will be skipped because we can't predict what the UID of the
     Administrator account will be.
     """
+    description = (
+        "Verifies AD Global Catalog and Domain Controller values in "
+        "sssctl"
+    )
+
     @duration
     def check(self):
         if not self.registry.trust_agent:
@@ -362,6 +374,10 @@ class IPAsidgenpluginCheck(IPAPlugin):
     """
     Verify that the sidgen 389-ds plugins are enabled
     """
+    description = (
+        "Verifies the sidgen plugin is enabled in the IPA 389-ds instance"
+    )
+
     @duration
     def check(self):
         if not self.registry.trust_agent:
@@ -407,6 +423,8 @@ class IPATrustAgentMemberCheck(IPAPlugin):
     """
     Verify that the current host is a member of adtrust agents
     """
+    description = "Verifies the host is a member of the adtrust agents group"
+
     @duration
     def check(self):
         if not self.registry.trust_agent:
@@ -448,6 +466,11 @@ class IPATrustControllerPrincipalCheck(IPAPlugin):
     """
     Verify that the current host cifs principal is a member of adtrust agents
     """
+    description = (
+        "Verifies the cifs principal is a member of the adtrust agents "
+        "group"
+    )
+
     @duration
     def check(self):
         if not self.registry.trust_controller:
@@ -491,6 +514,8 @@ class IPATrustControllerServiceCheck(IPAPlugin):
     """
     Verify that the current host starts the ADTRUST service.
     """
+    description = "Verifies the ADTRUST service is enabled in ipactl"
+
     @duration
     def check(self):
         if not self.registry.trust_controller:
@@ -536,6 +561,8 @@ class IPATrustControllerConfCheck(IPAPlugin):
 
     This is expected to be expanded over time.
     """
+    description = "Verifies ldapi is enabled for the passdb backend"
+
     @duration
     def check(self):
         if not self.registry.trust_controller:
@@ -598,6 +625,10 @@ class IPATrustControllerGroupSIDCheck(IPAPlugin):
     """
     Verify that the admins group's SID ends with 512 (Domain Admins RID)
     """
+    description = (
+        "Verifies the admins group SID ends with 512 (Domain Admins RID)"
+    )
+
     @duration
     def check(self):
         if not self.registry.trust_controller:
@@ -683,6 +714,8 @@ class IPATrustPackageCheck(IPAPlugin):
     able to resolve users/groups via extdom plugin and sssd but won't
     be able to do framework-specific operations.
     """
+    description = "Verifies the trust-ad sub-package is installed when needed"
+
     @duration
     def check(self):
         if self.registry.trust_controller:

--- a/src/ipahealthcheck/meta/core.py
+++ b/src/ipahealthcheck/meta/core.py
@@ -19,6 +19,10 @@ logger = logging.getLogger()
 
 @registry
 class MetaCheck(Plugin):
+    description = (
+        "Provides basic IPA master information including FQDN and version"
+    )
+
     @duration
     def check(self):
 

--- a/src/ipahealthcheck/meta/services.py
+++ b/src/ipahealthcheck/meta/services.py
@@ -94,6 +94,8 @@ class IPAServiceCheck(ServiceCheck):
 
 @registry
 class certmonger(IPAServiceCheck):
+    description = "Checks if the certmonger service is running"
+
     def check(self, instance=''):
         self.service_name = 'certmonger'
 
@@ -102,6 +104,8 @@ class certmonger(IPAServiceCheck):
 
 @registry
 class dirsrv(IPAServiceCheck):
+    description = "Checks if the dirsrv service is running"
+
     def check(self, instance=''):
         self.service_name = 'dirsrv'
 
@@ -110,6 +114,8 @@ class dirsrv(IPAServiceCheck):
 
 @registry
 class gssproxy(IPAServiceCheck):
+    description = "Checks if the gssproxy service is running"
+
     def check(self, instance=''):
         self.service_name = 'gssproxy'
 
@@ -118,6 +124,8 @@ class gssproxy(IPAServiceCheck):
 
 @registry
 class httpd(IPAServiceCheck):
+    description = "Checks if the httpd service is running"
+
     def check(self, instance=''):
         self.service_name = 'httpd'
 
@@ -126,6 +134,7 @@ class httpd(IPAServiceCheck):
 
 @registry
 class ipa_custodia(IPAServiceCheck):
+    description = "Checks if the ipa-custodia service is running"
     requires = ('dirsrv',)
 
     def check(self, instance=''):
@@ -140,6 +149,8 @@ class ipa_custodia(IPAServiceCheck):
 
 @registry
 class ipa_otpd(IPAServiceCheck):
+    description = "Checks if the ipa-otpd service is running"
+
     def check(self, instance=''):
         self.service_name = 'ipa-otpd'
 
@@ -148,6 +159,7 @@ class ipa_otpd(IPAServiceCheck):
 
 @registry
 class kadmin(IPAServiceCheck):
+    description = "Checks if the kadmin service is running"
     requires = ('dirsrv',)
 
     def check(self, instance=''):
@@ -162,6 +174,7 @@ class kadmin(IPAServiceCheck):
 
 @registry
 class krb5kdc(IPAServiceCheck):
+    description = "Checks if the krb5kdc service is running"
     requires = ('dirsrv',)
 
     def check(self, instance=''):
@@ -176,6 +189,7 @@ class krb5kdc(IPAServiceCheck):
 
 @registry
 class named(IPAServiceCheck):
+    description = "Checks if the named service is running"
     requires = ('dirsrv',)
 
     def check(self, instance=''):
@@ -190,6 +204,7 @@ class named(IPAServiceCheck):
 
 @registry
 class ods_enforcerd(IPAServiceCheck):
+    description = "Checks if the ods-enforcerd service is running"
     requires = ('dirsrv',)
 
     def check(self, instance=''):
@@ -204,6 +219,7 @@ class ods_enforcerd(IPAServiceCheck):
 
 @registry
 class ipa_dnskeysyncd(IPAServiceCheck):
+    description = "Checks if the ipa-dnskeysyncd service is running"
     requires = ('dirsrv',)
 
     def check(self, instance=''):
@@ -218,6 +234,7 @@ class ipa_dnskeysyncd(IPAServiceCheck):
 
 @registry
 class pki_tomcatd(IPAServiceCheck):
+    description = "Checks if the pki-tomcatd service is running"
     requires = ('dirsrv',)
 
     def check(self, instance=''):
@@ -232,6 +249,8 @@ class pki_tomcatd(IPAServiceCheck):
 
 @registry
 class sssd(IPAServiceCheck):
+    description = "Checks if the sssd service is running"
+
     def check(self, instance=''):
         self.service_name = 'sssd'
 
@@ -240,6 +259,8 @@ class sssd(IPAServiceCheck):
 
 @registry
 class chronyd(IPAServiceCheck):
+    description = "Checks if the chronyd service is running"
+
     def check(self, instance=''):
         self.service_name = 'chronyd'
 
@@ -248,6 +269,7 @@ class chronyd(IPAServiceCheck):
 
 @registry
 class smb(IPAServiceCheck):
+    description = "Checks if the smb service is running"
     requires = ('dirsrv',)
 
     def check(self, instance=''):
@@ -262,6 +284,7 @@ class smb(IPAServiceCheck):
 
 @registry
 class winbind(IPAServiceCheck):
+    description = "Checks if the winbind service is running"
     requires = ('dirsrv',)
 
     def check(self, instance=''):

--- a/src/ipahealthcheck/system/filesystemspace.py
+++ b/src/ipahealthcheck/system/filesystemspace.py
@@ -33,6 +33,7 @@ def in_container():
 @registry
 class FileSystemSpaceCheck(SystemPlugin):
     """Check for filesystem available space."""
+    description = "Checks available disk space on important filesystem paths"
 
     # watch important directories for FreeIPA
     _pathchecks = {

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -77,3 +77,113 @@ def test_getLevel():
     assert constants.getLevel('ERROR') == constants.ERROR
     assert constants.getLevel('CRITICAL') == constants.CRITICAL
     assert constants.getLevel('FOO') == 'FOO'
+
+
+def test_Result_with_description():
+    """Test Result with a plugin that has description set"""
+    registry = Registry()
+
+    class PluginWithDescription(Plugin):
+        description = "This is a test description"
+
+        def __init__(self, registry):
+            super().__init__(registry)
+
+    p = PluginWithDescription(registry)
+    r = Result(p, constants.SUCCESS)
+
+    assert r.description == "This is a test description"
+
+    # Check that description appears in output
+    results = Results()
+    results.add(r)
+    output = list(results.output())
+    assert len(output) == 1
+    assert 'description' in output[0]
+    assert output[0]['description'] == "This is a test description"
+
+
+def test_Result_without_description():
+    """Test Result with a plugin that has no description"""
+    registry = Registry()
+    p = Plugin(registry)
+    r = Result(p, constants.SUCCESS)
+
+    assert r.description is None
+
+    # Check that description does NOT appear in output
+    results = Results()
+    results.add(r)
+    output = list(results.output())
+    assert len(output) == 1
+    assert 'description' not in output[0]
+
+
+def test_Result_with_explicit_description():
+    """Test Result created with source/check and explicit description"""
+    r = Result(None, constants.SUCCESS, source='test.source',
+               check='TestCheck', description='Explicit description')
+
+    assert r.description == 'Explicit description'
+
+    # Check that description appears in output
+    results = Results()
+    results.add(r)
+    output = list(results.output())
+    assert len(output) == 1
+    assert 'description' in output[0]
+    assert output[0]['description'] == 'Explicit description'
+
+
+def test_json_to_results_with_description():
+    """Test json_to_results() with description in input data"""
+    from ipahealthcheck.core.plugin import json_to_results
+
+    json_data = [
+        {
+            'source': 'test.source',
+            'check': 'TestCheck',
+            'result': 'SUCCESS',
+            'uuid': '00000000-0000-0000-0000-000000000000',
+            'when': '20250101000000Z',
+            'duration': '0.000001',
+            'description': 'Test description from JSON',
+            'kw': {}
+        }
+    ]
+
+    results = json_to_results(json_data)
+    assert len(results.results) == 1
+    assert results.results[0].description == 'Test description from JSON'
+
+    # Check that description appears in output
+    output = list(results.output())
+    assert len(output) == 1
+    assert 'description' in output[0]
+    assert output[0]['description'] == 'Test description from JSON'
+
+
+def test_json_to_results_without_description():
+    """Test json_to_results() without description (backward compat)"""
+    from ipahealthcheck.core.plugin import json_to_results
+
+    json_data = [
+        {
+            'source': 'test.source',
+            'check': 'TestCheck',
+            'result': 'SUCCESS',
+            'uuid': '00000000-0000-0000-0000-000000000000',
+            'when': '20250101000000Z',
+            'duration': '0.000001',
+            'kw': {}
+        }
+    ]
+
+    results = json_to_results(json_data)
+    assert len(results.results) == 1
+    assert results.results[0].description is None
+
+    # Check that description does NOT appear in output
+    output = list(results.output())
+    assert len(output) == 1
+    assert 'description' not in output[0]


### PR DESCRIPTION
Add a description class attribute to Plugin that flows through to Result and appears in JSON output when set. This makes healthcheck results self-documenting by including human-readable descriptions of what each check does.

The description field is optional and only included in JSON output when not None, maintaining backward compatibility with existing consumers.

Added descriptions to 54 checks documented in README.md across dogtag, ipa, meta, and system modules. Checks without descriptions in the README inherit None and omit the field from output.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Add an optional human-readable description field to health check results and populate it across key plugins for more self-describing output.

New Features:
- Expose an optional description attribute on plugins that propagates into Result objects and JSON output when set.

Enhancements:
- Populate description text for numerous IPA, Dogtag, meta, and system health checks to document what each check validates in the JSON output.

Tests:
- Add tests covering Result description behavior, JSON serialization/deserialization with and without descriptions, and backward compatibility when the field is absent.