### PR TITLE
Correct the logic on trust checking in IPATrustPackageCheck

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fedora-release: [41, 42]
+        fedora-release: [43, 44]
 
     steps:
     - uses: actions/checkout@v4

--- a/src/ipahealthcheck/ipa/trust.py
+++ b/src/ipahealthcheck/ipa/trust.py
@@ -685,15 +685,13 @@ class IPATrustPackageCheck(IPAPlugin):
     """
     @duration
     def check(self):
-        if self.registry.trust_controller:
-            logger.debug('Trust controller, skipping')
+        if (
+            not self.registry.trust_controller
+            and not self.registry.trust_agent
+        ):
+            logger.debug('Not a trust controller or agent, skipping')
             yield Result(self, constants.SUCCESS,
-                         msg="Skipped. Not a trust controller")
-            return
-        if not self.registry.trust_agent:
-            logger.debug('Not a trust agent, skipping')
-            yield Result(self, constants.SUCCESS,
-                         msg="Skipped. Not a trust agent")
+                         msg="Skipped. Not a trust controller or agent")
             return
 
         # The trust-ad package provides this import


### PR DESCRIPTION
The check would be skipped if either not a trust controller or
a trust agent. It should skip it if both conditions are true.

This resulted in an incorrect message in the output because it
skipped if the server was a controller. If it was not then
the function exited without checking to see if it was an agent
instead.

Fixes: https://github.com/freeipa/freeipa-healthcheck/issues/378

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

Also update the Fedora versions to test against.

## Summary by Sourcery

Fix trust role detection in IPATrustPackageCheck and update CI Fedora test matrix.

Bug Fixes:
- Correct trust controller/agent check to only skip when the server is neither a trust controller nor a trust agent, preventing incorrect skip messages.

CI:
- Update GitHub Actions Fedora release matrix to test against Fedora 43 and 44.